### PR TITLE
Fix pip install and install module commands as command line tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ readme = "README.md"
 authors = [
     {name = "Norbert Podhorszki", email = "pnorbert@ornl.gov"}
 ]
-license = {file = "LICENSE"}
+
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+
 dynamic = ["version"]
 keywords = ["campaign", "remote data", "adios2", "hdf5"]
 classifiers = [
@@ -20,7 +23,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Education",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
+    #"License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3.10",
@@ -39,12 +42,20 @@ dependencies = [
 ]
 
 [project.urls]
-Source = "//https://github.com/ornladios/hpc-campaign"
+Source = "https://github.com/ornladios/hpc-campaign"
 Tracker = "https://github.com/ornladios/hpc-campaign/issues"
 Documentation = "https://hpc-campaign.readthedocs.io/en/latest/"
 
-[tool.setuptools]
-packages = ["hpc-campaign"]
+[tool.setuptools.packages.find]
+where = ["source"]
+
+[project.scripts]
+hpc_campaign_cache = "hpc_campaign_cache:main"
+hpc_campaign_connector = "hpc_campaign_connector:main"
+hpc_campaign_genkey = "hpc_campaign_genkey:main"
+hpc_campaign_hdf5_metadata = "hpc_campaign_hdf5_metadata:main"
+hpc_campaign_list = "hpc_campaign_list:main"
+hpc_campaign_manager = "hpc_campaign_manager:main"
 
 [tool.black] 
 line-length = 120
@@ -53,3 +64,4 @@ line-length = 120
 include = ["source"]
 exclude = ["**/__pycache__"]
 reportPossiblyUnboundVariable = false
+

--- a/source/hpc_campaign_cache.py
+++ b/source/hpc_campaign_cache.py
@@ -179,7 +179,7 @@ def connect_to_redis(host: str, port: int, db: int) -> redis.Redis:
     return r
 
 
-if __name__ == "__main__":
+def main():
     # default values
     cfg = Config()
     args = setup_args(cfg)
@@ -205,3 +205,8 @@ if __name__ == "__main__":
             print("Missing campaign archive argument for clearing cache")
             exit(1)
         clear_cache(args, cfg, kvdb)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/source/hpc_campaign_connector.py
+++ b/source/hpc_campaign_connector.py
@@ -1500,5 +1500,10 @@ def start_server(argv):
             server.server_close()
 
 
-if __name__ == "__main__":
+def main():
     start_server(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()
+

--- a/source/hpc_campaign_genkey.py
+++ b/source/hpc_campaign_genkey.py
@@ -51,7 +51,7 @@ def check_path_for_reading(path: str):
         exit(1)
 
 
-if __name__ == "__main__":
+def main():
     args = setup_args()
     key = Key()
     if args.command == "generate":
@@ -68,3 +68,7 @@ if __name__ == "__main__":
         check_path_for_reading(args.path)
         key.read(args.path)
         key.info(False)
+
+if __name__ == "__main__":
+    main()
+

--- a/source/hpc_campaign_hdf5_metadata.py
+++ b/source/hpc_campaign_hdf5_metadata.py
@@ -94,9 +94,14 @@ def IsHDF5Dataset(dataset):
     return it_is
 
 
-if __name__ == "__main__":
+def main():
     infilename = sys.argv[1]
     outfilename = sys.argv[2]
     insize, outsize = copy_hdf5_file_without_data(infilename, outfilename, log=True)
     print(f"{infilename} size = {insize}")
     print(f"{outfilename} size = {outsize}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/source/hpc_campaign_list.py
+++ b/source/hpc_campaign_list.py
@@ -107,7 +107,12 @@ def _List(args: argparse.Namespace, collect: bool = True) -> list[str]:
     return result
 
 
-if __name__ == "__main__":
+def main():
     args = _SetupArgs()
     _CheckCampaignStore(args)
     _List(args, collect=False)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/source/hpc_campaign_manager.py
+++ b/source/hpc_campaign_manager.py
@@ -1018,7 +1018,8 @@ def DeleteCampaignFile(args: argparse.Namespace):
         return 1
 
 
-if __name__ == "__main__":
+
+def main():
     parser = ArgParser()
     CheckCampaignStore(parser.args)
 
@@ -1092,3 +1093,8 @@ if __name__ == "__main__":
             print(f"  {e.sqlite_errorcode}  {e.sqlite_errorname}: {e}")
         print("!!!!")
         print()
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
- Updated deprecated license formatting in `pyproject.toml`
- Fixed error in source URL
- Uses `tool.setuptools.packages.find` to say how to find package files
- `project.scripts` installs equivalent of `-m` modules as command line tools. Added `main()` functions to support this.