### PR TITLE
Import hpc_campagin as Python module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,16 +47,19 @@ Source = "https://github.com/ornladios/hpc-campaign"
 Tracker = "https://github.com/ornladios/hpc-campaign/issues"
 Documentation = "https://hpc-campaign.readthedocs.io/en/latest/"
 
-[tool.setuptools.packages.find]
-where = ["source"]
+[tool.setuptools]
+packages = ["hpc_campaign"]
+
+[tool.setuptools.package-dir]
+hpc_campaign = "source"
 
 [project.scripts]
-hpc_campaign_cache = "hpc_campaign_cache:main"
-hpc_campaign_connector = "hpc_campaign_connector:main"
-hpc_campaign_genkey = "hpc_campaign_genkey:main"
-hpc_campaign_hdf5_metadata = "hpc_campaign_hdf5_metadata:main"
-hpc_campaign_list = "hpc_campaign_list:main"
-hpc_campaign_manager = "hpc_campaign_manager:main"
+hpc_campaign_cache = "hpc_campaign.hpc_campaign_cache:main"
+hpc_campaign_connector = "hpc_campaign.hpc_campaign_connector:main"
+hpc_campaign_genkey = "hpc_campaign.hpc_campaign_genkey:main"
+hpc_campaign_hdf5_metadata = "hpc_campaign.hpc_campaign_hdf5_metadata:main"
+hpc_campaign_list = "hpc_campaign.hpc_campaign_list:main"
+hpc_campaign_manager = "hpc_campaign.hpc_campaign_manager:main"
 
 [tool.black] 
 line-length = 120

--- a/source/__init__.py
+++ b/source/__init__.py
@@ -1,0 +1,1 @@
+from hpc_campaign.hpc_campaign_list import List

--- a/source/hpc_campaign_cache.py
+++ b/source/hpc_campaign_cache.py
@@ -12,8 +12,8 @@ from time import sleep
 
 import redis.exceptions
 
-from hpc_campaign_config import Config, REDIS_PORT
-from hpc_campaign_utils import timestamp_to_datetime, input_yes_or_no
+from hpc_campaign.hpc_campaign_config import Config, REDIS_PORT
+from hpc_campaign.hpc_campaign_utils import timestamp_to_datetime, input_yes_or_no
 
 
 def setup_args(cfg: Config):

--- a/source/hpc_campaign_connector.py
+++ b/source/hpc_campaign_connector.py
@@ -20,7 +20,7 @@ from urllib.parse import urlparse, parse_qs
 from os.path import expanduser
 from datetime import datetime
 
-from hpc_campaign_key import Key, read_key
+from hpc_campaign.hpc_campaign_key import Key, read_key
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/source/hpc_campaign_genkey.py
+++ b/source/hpc_campaign_genkey.py
@@ -2,7 +2,7 @@
 import argparse
 from os import remove
 from os.path import exists
-from hpc_campaign_key import Key
+from hpc_campaign.hpc_campaign_key import Key
 
 
 def setup_args():

--- a/source/hpc_campaign_list.py
+++ b/source/hpc_campaign_list.py
@@ -6,7 +6,7 @@ import re
 import fnmatch
 from os.path import exists, isdir, dirname, basename, expanduser
 
-from hpc_campaign_config import Config, ADIOS_ACA_VERSION
+from hpc_campaign.hpc_campaign_config import Config, ADIOS_ACA_VERSION
 
 
 def List(*patterns, wildcard: bool = False):

--- a/source/hpc_campaign_manager.py
+++ b/source/hpc_campaign_manager.py
@@ -17,11 +17,11 @@ from re import sub
 from socket import getfqdn
 from time import time_ns, sleep
 
-from hpc_campaign_key import read_key
-from hpc_campaign_config import ADIOS_ACA_VERSION
-from hpc_campaign_utils import timestamp_to_str, SQLCommit, SQLExecute, SQLErrorList, get_folder_size, sizeof_fmt
-from hpc_campaign_hdf5_metadata import copy_hdf5_file_without_data, IsHDF5Dataset
-from hpc_campaign_manager_args import ArgParser
+from hpc_campaign.hpc_campaign_key import read_key
+from hpc_campaign.hpc_campaign_config import ADIOS_ACA_VERSION
+from hpc_campaign.hpc_campaign_utils import timestamp_to_str, SQLCommit, SQLExecute, SQLErrorList, get_folder_size, sizeof_fmt
+from hpc_campaign.hpc_campaign_hdf5_metadata import copy_hdf5_file_without_data, IsHDF5Dataset
+from hpc_campaign.hpc_campaign_manager_args import ArgParser
 
 CURRENT_TIME = time_ns()
 

--- a/source/hpc_campaign_manager_args.py
+++ b/source/hpc_campaign_manager_args.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 from os.path import exists, basename
 
-from hpc_campaign_config import Config
+from hpc_campaign.hpc_campaign_config import Config
 
 __accepted_commands__ = [
     "create",


### PR DESCRIPTION
Pip install now works for `import hpc_campaign`. Currently only function is `List()`, but can also do statements like `import hpc_campaign.hpc_campaign_utils` to use anything therein. And the source files have been updated for that usage. Before, the install was creating separate modules for source files (like `import hpc_campaign_utils`), which wasn't intended.