### PR TITLE
Extending module execution

### DIFF
--- a/hpc_campaign/__main__.py
+++ b/hpc_campaign/__main__.py
@@ -1,6 +1,6 @@
 import sys
 import argparse
-from .list import main as List
+
 
 
 def ArgParse():
@@ -10,16 +10,37 @@ def ArgParse():
         add_help=False
     parser = argparse.ArgumentParser(add_help=add_help, prog="hpc_campaign")
 
-    parser.add_argument("subcmd", help='Sub command', choices=["list"])
+    parser.add_argument(
+        "subcmd",
+        help='Sub command',
+        choices=[
+            "cache",
+            "connector",
+            "genkey",
+            "hdf5_metadata",
+            "list",
+            "manager",
+        ]
+    )
+
     known, unknown = parser.parse_known_args()
 
     return known.subcmd, unknown
 
 
-if __name__ == "__main__":
+def main():
 
     subcmd, args = ArgParse()
     prog = "hpc_campaign {0}".format(subcmd)
 
-    if subcmd == "list":
-        List(args=args, prog=prog)
+    exec(
+        'from .{0} import main as cmd'.format(subcmd),
+        globals=globals()
+    )
+
+    cmd(args=args, prog=prog)
+
+
+if __name__ == "__main__":
+    
+    main()

--- a/hpc_campaign/cache.py
+++ b/hpc_campaign/cache.py
@@ -16,8 +16,8 @@ from .config import Config, REDIS_PORT
 from .utils import timestamp_to_datetime, input_yes_or_no
 
 
-def setup_args(cfg: Config):
-    parser = argparse.ArgumentParser()
+def setup_args(cfg: Config, args=None, prog=None):
+    parser = argparse.ArgumentParser(prog=prog)
     parser.add_argument(
         "command",
         help="Command: list/clear",
@@ -27,7 +27,7 @@ def setup_args(cfg: Config):
     parser.add_argument("--redis-port", "-p", help="Key-value database port", default=REDIS_PORT)
     parser.add_argument("--verbose", "-v", help="More verbosity", action="count", default=0)
     parser.add_argument("--yes-to-all", "-y", help="Answer yes automatically", action="store_true", default=False)
-    args = parser.parse_args()
+    args = parser.parse_args(args=args)
 
     args.CampaignFileName = args.campaign
     if args.campaign is not None:
@@ -179,10 +179,10 @@ def connect_to_redis(host: str, port: int, db: int) -> redis.Redis:
     return r
 
 
-def main():
+def main(args=None, prog=None):
     # default values
     cfg = Config()
-    args = setup_args(cfg)
+    args = setup_args(cfg, args=args, prog=prog)
     if not cfg.cache_path:
         print("No cachepath specified in user config")
         exit(1)

--- a/hpc_campaign/connector.py
+++ b/hpc_campaign/connector.py
@@ -1500,8 +1500,8 @@ def start_server(argv):
             server.server_close()
 
 
-def main():
-    start_server(sys.argv[1:])
+def main(args=sys.argv[1:], prog=None):
+    start_server(args)
 
 
 if __name__ == "__main__":

--- a/hpc_campaign/genkey.py
+++ b/hpc_campaign/genkey.py
@@ -5,8 +5,8 @@ from os.path import exists
 from .key import Key
 
 
-def setup_args():
-    parser = argparse.ArgumentParser()
+def setup_args(args=None, prog=None):
+    parser = argparse.ArgumentParser(prog=prog)
     parser.add_argument(
         "command",
         help="Command: generate/verify/info",
@@ -15,7 +15,7 @@ def setup_args():
     parser.add_argument("path", help="path of keyfile")
     parser.add_argument("--verbose", "-v", help="More verbosity", action="count", default=0)
     parser.add_argument("--password", "-p", help="Protect with password", action="store_true", default=False)
-    args = parser.parse_args()
+    args = parser.parse_args(args=args)
 
     if args.verbose > 0:
         print(f"# Verbosity = {args.verbose}")
@@ -51,8 +51,8 @@ def check_path_for_reading(path: str):
         exit(1)
 
 
-def main():
-    args = setup_args()
+def main(args=None, prog=None):
+    args = setup_args(args=args, prog=prog)
     key = Key()
     if args.command == "generate":
         check_path_for_creation(args.path)

--- a/hpc_campaign/hdf5_metadata.py
+++ b/hpc_campaign/hdf5_metadata.py
@@ -94,9 +94,8 @@ def IsHDF5Dataset(dataset):
     return it_is
 
 
-def main():
-    infilename = sys.argv[1]
-    outfilename = sys.argv[2]
+def main(args=sys.argv[1:3], prog=None):
+    infilename, outfilename = args
     insize, outsize = copy_hdf5_file_without_data(infilename, outfilename, log=True)
     print(f"{infilename} size = {insize}")
     print(f"{outfilename} size = {outsize}")

--- a/hpc_campaign/list.py
+++ b/hpc_campaign/list.py
@@ -37,7 +37,7 @@ def _SetupArgs(args=None, prog=None):
     )
     parser.add_argument("-s", "--campaign_store", help="Path to local campaign store", default=None)
     parser.add_argument("-v", "--verbose", help="More verbosity", action="count", default=0)
-    args = parser.parse_args(args)
+    args = parser.parse_args(args=args)
     return _SetDefaults(args)
 
 

--- a/hpc_campaign/manager.py
+++ b/hpc_campaign/manager.py
@@ -1019,8 +1019,8 @@ def DeleteCampaignFile(args: argparse.Namespace):
 
 
 
-def main():
-    parser = ArgParser()
+def main(args=None, prog=None):
+    parser = ArgParser(args=args, prog=prog)
     CheckCampaignStore(parser.args)
 
     if parser.args.keyfile:

--- a/hpc_campaign/manager_args.py
+++ b/hpc_campaign/manager_args.py
@@ -34,9 +34,9 @@ class ArgParser:
 
     """
 
-    def __init__(self):
-        self.parsers = self.setup_args()
-        self.commandlines = self.divide_cmdline(__accepted_commands__)
+    def __init__(self, args=sys.argv[1:], prog=prog):
+        self.parsers = self.setup_args(prog=prog)
+        self.commandlines = self.divide_cmdline(__accepted_commands__, args=args)
         self.args = self.parse_args_main(self.parsers["main"], self.commandlines[0])
         self.cmdidx = 1
         self.prev_command = None
@@ -57,10 +57,10 @@ class ArgParser:
         else:
             return False
 
-    def divide_cmdline(self, commands: list):
+    def divide_cmdline(self, commands: list, args=sys.argv[1:]):
         # Divide argv by commands
         split_argv = [[]]
-        for c in sys.argv[1:]:
+        for c in args:
             if c in commands:
                 split_argv.append([c])
             else:
@@ -146,7 +146,7 @@ class ArgParser:
                     "Invalid arguments for text: when using --name <name>, " "only one text file is allowed"
                 )
 
-    def setup_args(self) -> dict:
+    def setup_args(self, prog=prog) -> dict:
         parser = argparse.ArgumentParser(
             formatter_class=argparse.RawDescriptionHelpFormatter,
             epilog="""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,12 +57,7 @@ packages = ["hpc_campaign"]
 version = { attr = "hpc_campaign.__version__" }
 
 [project.scripts]
-hpc_campaign_cache = "hpc_campaign.cache:main"
-hpc_campaign_connector = "hpc_campaign.connector:main"
-hpc_campaign_genkey = "hpc_campaign.genkey:main"
-hpc_campaign_hdf5_metadata = "hpc_campaign.hdf5_metadata:main"
-hpc_campaign_list = "hpc_campaign.list:main"
-hpc_campaign_manager = "hpc_campaign.manager:main"
+hpc_campaign="hpc_campaign.__main__:main"
 
 [tool.black] 
 line-length = 120


### PR DESCRIPTION
Updating to being supporting module execution that won't throw the warning about ambiguous import.
```
python -m hpc_campaign list --help
```