### PR TITLE
Remove keyword on exec for compatibility with older versions of python

### DIFF
--- a/hpc_campaign/__main__.py
+++ b/hpc_campaign/__main__.py
@@ -35,7 +35,7 @@ def main():
 
     exec(
         'from .{0} import main as cmd'.format(subcmd),
-        globals=globals()
+        globals()
     )
 
     cmd(args=args, prog=prog)


### PR DESCRIPTION
Keyword was new in 3.13