### PR TITLE
More transparent syntax import in __main__.py

### DIFF
--- a/hpc_campaign/__main__.py
+++ b/hpc_campaign/__main__.py
@@ -1,13 +1,13 @@
 import sys
 import argparse
-
+import importlib
 
 
 def ArgParse():
     if ('--help' in sys.argv) and (sys.argv[1] == '--help'):
         add_help = True
     else:
-        add_help=False
+        add_help = False
     parser = argparse.ArgumentParser(add_help=add_help, prog="hpc_campaign")
 
     parser.add_argument(
@@ -33,14 +33,22 @@ def main():
     subcmd, args = ArgParse()
     prog = "hpc_campaign {0}".format(subcmd)
 
+    '''
     exec(
         'from .{0} import main as cmd'.format(subcmd),
         globals()
     )
 
     cmd(args=args, prog=prog)
+    '''
+
+    # Dynamically import the module using importlib.import_module()
+    aliased_module = importlib.import_module(".{0}".format(subcmd), package="hpc_campaign")
+
+    # Run main()
+    aliased_module.main(args=args, prog=prog)
 
 
 if __name__ == "__main__":
-    
+
     main()

--- a/hpc_campaign/manager_args.py
+++ b/hpc_campaign/manager_args.py
@@ -148,13 +148,14 @@ class ArgParser:
 
     def setup_args(self, prog=prog) -> dict:
         parser = argparse.ArgumentParser(
+            prog=prog,
             formatter_class=argparse.RawDescriptionHelpFormatter,
             epilog="""
 A campaign archive name without '.aca' extension will be forced to have '.aca'.
 If it exists, 'campaignstorepath' in ~/.config/hpc-campaign/config.yaml will be used for
 relative paths for <archive> names.
 Multiple commands can be used in one run.
-Type '%(prog)s x <command> -h' for help on commands.
+Type '%(prog)s <archive> <command> -h' for help on commands.
 """,
         )
         parsers = {}


### PR DESCRIPTION
Simple equivalent that's now recognized by `flake8`.