### PR TITLE
ACA 0.6

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,8 +6,8 @@ project = 'HPC Campaign Management'
 copyright = '2024, ORNL ADIOS Team'
 author = 'Norbert Podhorszki'
 
-release = '0.5'
-version = '0.5.0'
+release = '0.6'
+version = '0.6.0'
 
 # -- General configuration
 

--- a/hpc_campaign/__init__.py
+++ b/hpc_campaign/__init__.py
@@ -1,3 +1,3 @@
 from .list import List
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/hpc_campaign/cache.py
+++ b/hpc_campaign/cache.py
@@ -155,7 +155,6 @@ def clear_cache(args: argparse.Namespace, cfg: Config, kvdb: redis.Redis):
     info = res.fetchone()
     t = timestamp_to_datetime(info[3])
     print(f"{info[1]}, version {info[2]}, created on {t}")
-    version = float(info[2])
 
     res = cur.execute("select rowid, uuid, name, modtime from dataset")
     datasets = res.fetchall()
@@ -169,7 +168,7 @@ def clear_cache(args: argparse.Namespace, cfg: Config, kvdb: redis.Redis):
     con.close()
 
 
-def connect_to_redis(host: str, port: int, db: int) -> redis.Redis:
+def connect_to_redis(host: str, port: int, db: int) -> redis.Redis | None:
     r = redis.Redis(host=host, port=port, db=db)
     try:
         r.ping()
@@ -209,4 +208,3 @@ def main(args=None, prog=None):
 
 if __name__ == "__main__":
     main()
-

--- a/hpc_campaign/config.py
+++ b/hpc_campaign/config.py
@@ -3,11 +3,12 @@
 import yaml
 from os.path import expanduser
 
-ACA_VERSION = "0.5"
+ACA_VERSION = "0.6"
 # 0.2 added key encryption (added table key, modfified table bpdataset)
 # 0.3 generate UUID for each bpdataset (modified table bpdataset)
 # 0.4 added h5dataset table
 # 0.5 reorganized to "dataset" table, plus text and images, replicas, archives
+# 0.6 redefines "archive" as TAR files, throws away 0.5's archive concept
 
 REDIS_PORT = 6379
 

--- a/hpc_campaign/genkey.py
+++ b/hpc_campaign/genkey.py
@@ -69,6 +69,6 @@ def main(args=None, prog=None):
         key.read(args.path)
         key.info(False)
 
+
 if __name__ == "__main__":
     main()
-

--- a/hpc_campaign/hdf5_metadata.py
+++ b/hpc_campaign/hdf5_metadata.py
@@ -103,4 +103,3 @@ def main(args=sys.argv[1:3], prog=None):
 
 if __name__ == "__main__":
     main()
-

--- a/hpc_campaign/list.py
+++ b/hpc_campaign/list.py
@@ -115,4 +115,3 @@ def main(args=None, prog=None):
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
  Table changes:
  - table 'host' has a 'default_protocol' which is used for https for now, empty for others
  - table 'archive' has 'tarname' for TAR files or "" for the actual directory,
    - one directory may contain now multiple archives (TAR files but itself for individual files)
  - table 'replica' has 'archiveid', 0 for non-archives, otherwise rowid in 'archive' table

  New features
  - added "https" as an archive type (see manager add-archival-storage command)
  - manager archived command: optional "--archiveid" uniquely points to a specific archive in a directory

  TODO for completing ACA 0.6:
  - modify S3 for archive type like https
  - support tar index to register the offset/size location of each file in that tar file