### PR TITLE
Reducing the size of the build in the CI

### DIFF
--- a/.dockerignore‎
+++ b/.dockerignore‎
@@ -1,0 +1,6 @@
+.git
+.venv
+__pycache__
+.pytest_cache
+dist
+htmlcov

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,8 +16,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install poetry
-        poetry install
+        pip install --no-cache-dir poetry poetry-plugin-export
+        poetry export -f requirements.txt -o requirements.txt --without-hashes --with dev
+        pip install --no-cache-dir -r requirements.txt && rm requirements.txt
 
     - name: Run ruff
       run: poetry run ruff check

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -5,17 +5,17 @@ FROM python:3.13-slim
 WORKDIR /app
 
 # Install poetry
-RUN pip install poetry
+RUN pip install --no-cache-dir poetry poetry-plugin-export
 
 # Copy the dependency files to the working directory
+COPY pyproject.toml poetry.lock ./
+
+# Using poetry to make a requirements.txt then pip to do the install.
+# Pip is aggressive with storage space.
+RUN poetry export -f requirements.txt -o requirements.txt --without-hashes --with dev
+
+RUN pip install --no-cache-dir -r requirements.txt \
+    && rm requirements.txt
+
 # Copy the rest of the application code to the working directory
 COPY . .
-#COPY pyproject.toml poetry.lock README.md ./
-
-
-# Install project dependencies
-RUN poetry install
-
-
-
-# No CMD or ENTRYPOINT is specified as this is for CI/CD


### PR DESCRIPTION
We noticed this issue on our repo, so I am applying here the same fix to improved the storage utilization of the image by caching packages that get installed. The github actions are now split into two workflows and the image is tested separately. 