### PR TITLE
Add visualization convenience API and in-memory image support

### DIFF
--- a/docs/source/usage_api.rst
+++ b/docs/source/usage_api.rst
@@ -124,6 +124,59 @@ Example usage:
 Additional options for images include:
 * `name="<NAME>"` representation name for the image in the campaign hierarchy
 
+**Derived visualizations**
+
+Use ``visualization`` when an image or image sequence is derived from variables
+in a data set already in the campaign. The method adds the image data and also
+records explicit metadata that links the visualization back to the source data
+set and variable uses. This is useful in notebooks where a user reads a
+variable, performs analysis, creates figures, and wants to save those figures
+back into the campaign.
+
+Example usage:
+
+.. code-block:: python
+
+  manager.data("runs/run001/output.bp", name="run001/output.bp")
+
+  # png_frames can be paths, PNG/JPEG bytes, PIL Images, or matplotlib Figures.
+  # replace=True makes rerunning a notebook cell update the same visualization.
+  manager.visualization(
+      images=png_frames,
+      source_dataset="run001/output.bp",
+      name="density",
+      kind="heatmap",
+      color_by="rho",
+      steps=[0, 1, 2],
+      replace=True,
+  )
+
+  manager.visualization(
+      images=overlay_frames,
+      source_dataset="run001/output.bp",
+      name="density_current_overlay",
+      kind="heatmap-contour",
+      color_by="rho",
+      contour_by="current_z",
+      replace=True,
+  )
+
+  manager.visualization(
+      images=line_plot,
+      source_dataset="run001/output.bp",
+      name="mass_over_time",
+      kind="line-plot",
+      x_axis="time",
+      y_axis="mass",
+      replace=True,
+  )
+
+If ``name`` is a short token, the visualization sequence is stored under
+``<source_dataset>/visualizations/<name>``. For advanced use, pass
+``sequence_name`` to provide the exact sequence name. If image names are not
+provided explicitly, they are generated as children of the sequence name, using
+``steps`` when supplied.
+
 **4. text**
 
 Add one or more text files to the archive. If requested, text files are stored within the archive. In that case, zlib is used to compress the text file.
@@ -342,5 +395,4 @@ Comparing the campaign archive size to the data it points to can be done by the 
 
   $ du -sh /path/to/adios-campaign-store/demoproject/test_campaign_001 info.aca
   127K     /path/to/adios-campaign-store/demoproject/test_campaign_001 info.aca
-
 

--- a/hpc_campaign/info.py
+++ b/hpc_campaign/info.py
@@ -122,6 +122,43 @@ class TimeSeriesInfo:
 
 
 @dataclass
+class VisualizationVariableInfo:
+    """Variable-role association within a visualization sequence."""
+
+    name: str
+    role: str
+    source_dataset_id: int
+    source_dataset_name: str
+
+
+@dataclass
+class VisualizationItemInfo:
+    """Explicit sequence item reference."""
+
+    item_order: int
+    item_type: str
+    item_uuid: str
+    metadata: str | None
+    dataset_id: int | None
+    dataset_name: str | None
+    file_format: str | None
+
+
+@dataclass
+class VisualizationSequenceInfo:  # pylint: disable=too-many-instance-attributes
+    """Visualization sequence metadata entry."""
+
+    name: str
+    vis_type: str
+    thumbnail_item_uuid: str | None
+    thumbnail_dataset_id: int | None
+    thumbnail_dataset_name: str | None
+    metadata: str | None
+    variables: list[VisualizationVariableInfo] = field(default_factory=list)
+    items: list[VisualizationItemInfo] = field(default_factory=list)
+
+
+@dataclass
 class InfoResult:
     """Aggregated archive information."""
 
@@ -129,6 +166,7 @@ class InfoResult:
     hosts: list[HostInfo] = field(default_factory=list)
     keys: list[KeyInfo] = field(default_factory=list)
     time_series: dict[int, TimeSeriesInfo] = field(default_factory=dict)
+    visualization_sequences: dict[int, VisualizationSequenceInfo] = field(default_factory=dict)
     datasets: dict[int, DatasetInfo] = field(default_factory=dict)
 
 
@@ -424,7 +462,9 @@ def info_texts(  # pylint: disable=too-many-locals
         )
 
 
-def collect_info(args: argparse.Namespace, con: sqlite3.Connection) -> InfoResult:  # pylint: disable=too-many-locals
+def collect_info(  # pylint: disable=too-many-locals,too-many-statements
+    args: argparse.Namespace, con: sqlite3.Connection
+) -> InfoResult:
     cur = con.cursor()
     res = sql_execute(cur, "select id, name, version, modtime from info")
     row = res.fetchone()
@@ -538,6 +578,83 @@ def collect_info(args: argparse.Namespace, con: sqlite3.Connection) -> InfoResul
         info_texts(args, info_datasets, cur, dirs_archived)
         info_images(args, info_datasets, cur, dirs_archived)
 
+    res_tables = sql_execute(
+        cur,
+        "select name from sqlite_master where type = 'table' and name in "
+        "('visualization_sequence', 'visualization_variable', 'visualization_item')",
+    )
+    available_tables = {row[0] for row in res_tables.fetchall()}
+
+    if "visualization_sequence" in available_tables:
+        res_vis = sql_execute(
+            cur,
+            "select vs.visid, vs.name, vs.vistype, vs.thumbnail_itemuuid, vs.metadata, "
+            "thumb.rowid as thumbnail_datasetid, thumb.name as thumbnail_name "
+            "from visualization_sequence as vs "
+            "left join dataset as thumb on thumb.uuid = vs.thumbnail_itemuuid and thumb.deltime = 0 "
+            "order by vs.visid",
+        )
+        for row in res_vis:
+            vis_id = int(row["visid"])
+            info_datasets.visualization_sequences[vis_id] = VisualizationSequenceInfo(
+                name=row["name"],
+                vis_type=row["vistype"],
+                thumbnail_item_uuid=row["thumbnail_itemuuid"],
+                thumbnail_dataset_id=(
+                    int(row["thumbnail_datasetid"]) if row["thumbnail_datasetid"] is not None else None
+                ),
+                thumbnail_dataset_name=row["thumbnail_name"],
+                metadata=row["metadata"],
+            )
+
+    if "visualization_variable" in available_tables:
+        res_vis_vars = sql_execute(
+            cur,
+            "select vv.visid, vv.datasetid, d.name as dataset_name, vv.variable_name, vv.role "
+            "from visualization_variable as vv "
+            "join dataset as d on d.rowid = vv.datasetid "
+            "order by vv.visid, vv.datasetid, vv.role, vv.variable_name",
+        )
+        for row in res_vis_vars:
+            vis_id = int(row["visid"])
+            sequence_info = info_datasets.visualization_sequences.get(vis_id)
+            if sequence_info is None:
+                continue
+            sequence_info.variables.append(
+                VisualizationVariableInfo(
+                    name=row["variable_name"],
+                    role=row["role"],
+                    source_dataset_id=int(row["datasetid"]),
+                    source_dataset_name=row["dataset_name"],
+                )
+            )
+
+    if "visualization_item" in available_tables:
+        res_vis_items = sql_execute(
+            cur,
+            "select vi.visid, vi.item_order, vi.item_type, vi.item_uuid, vi.metadata, "
+            "d.rowid as datasetid, d.name as dataset_name, d.fileformat as dataset_fileformat "
+            "from visualization_item as vi "
+            "left join dataset as d on d.uuid = vi.item_uuid and d.deltime = 0 "
+            "order by vi.visid, vi.item_order",
+        )
+        for row in res_vis_items:
+            vis_id = int(row["visid"])
+            sequence_info = info_datasets.visualization_sequences.get(vis_id)
+            if sequence_info is None:
+                continue
+            sequence_info.items.append(
+                VisualizationItemInfo(
+                    item_order=int(row["item_order"]),
+                    item_type=row["item_type"],
+                    item_uuid=row["item_uuid"],
+                    metadata=row["metadata"],
+                    dataset_id=int(row["datasetid"]) if row["datasetid"] is not None else None,
+                    dataset_name=row["dataset_name"],
+                    file_format=row["dataset_fileformat"],
+                )
+            )
+
     return info_datasets
 
 
@@ -595,7 +712,7 @@ def format_info_dataset_lines(  # pylint: disable=too-many-locals
     return lines
 
 
-def format_info(info_data: InfoResult) -> str:
+def format_info(info_data: InfoResult) -> str:  # pylint: disable=too-many-statements
     lines = []
     archive_info = info_data.archive
     created_time = timestamp_to_str(archive_info.mod_time)
@@ -633,6 +750,41 @@ def format_info(info_data: InfoResult) -> str:
         lines.append("Other Datasets:")
         for _ds_id, dataset_info in sorted(info_data.datasets.items()):
             lines.extend(format_info_dataset_lines(dataset_info))
+        lines.append("")
+
+    if info_data.visualization_sequences:
+        lines.append("Visualization Sequences:")
+        for _vis_id, sequence_info in sorted(info_data.visualization_sequences.items()):
+            header = f"  {sequence_info.name}   type={sequence_info.vis_type}"
+            lines.append(header)
+            if sequence_info.thumbnail_dataset_name:
+                thumb_desc = sequence_info.thumbnail_dataset_name
+                if sequence_info.thumbnail_item_uuid:
+                    thumb_desc += f" ({sequence_info.thumbnail_item_uuid})"
+                lines.append(f"      thumbnail: {thumb_desc}")
+            if sequence_info.variables:
+                seen_sources: list[str] = []
+                for variable_info in sequence_info.variables:
+                    if variable_info.source_dataset_name not in seen_sources:
+                        seen_sources.append(variable_info.source_dataset_name)
+                lines.append(f"      sources: {', '.join(seen_sources)}")
+                for variable_info in sequence_info.variables:
+                    lines.append(
+                        f"      {variable_info.role}: {variable_info.name} "
+                        + f"(dataset {variable_info.source_dataset_name})"
+                    )
+            if sequence_info.items:
+                item_types = sorted({item.item_type for item in sequence_info.items})
+                lines.append(f"      items: {len(sequence_info.items)} ({', '.join(item_types)})")
+                for item_info in sequence_info.items[:3]:
+                    item_desc = item_info.item_uuid
+                    if item_info.dataset_name:
+                        item_desc += f" -> {item_info.dataset_name}"
+                    lines.append(f"      item[{item_info.item_order}]: {item_info.item_type} {item_desc}")
+                if len(sequence_info.items) > 3:
+                    lines.append(f"      ... {len(sequence_info.items) - 3} more item(s)")
+            if sequence_info.metadata:
+                lines.append(f"      metadata: {sequence_info.metadata}")
 
     return "\n".join(lines)
 

--- a/hpc_campaign/manager.py
+++ b/hpc_campaign/manager.py
@@ -10,16 +10,21 @@
 import argparse
 import sqlite3
 import sys
+from io import BytesIO
 from os.path import exists
 from pathlib import Path
 from time import time_ns
+
+from PIL import Image as PILImage
 
 from .info import InfoResult, collect_info, print_info
 from .key import read_key
 from .manager_args import ArgParser
 from .manager_funcs import (
     add_archival_storage,
+    add_image_data,
     add_time_series,
+    add_visualization_sequence,
     archive_dataset,
     check_archival_storage_system_name,
     create_tables,
@@ -201,6 +206,31 @@ class Manager:  # pylint: disable=too-many-public-methods
             self.open(create=True, truncate=False)
         update(cmd_args, self.cur, self.con)
 
+    def image_data(
+        self,
+        data: bytes,
+        image_format: str,
+        name: str | None = None,
+        thumbnail: list[int] | tuple[int, int] | None = None,
+        replica_name: str | None = None,
+    ):
+        thumb_value = None
+        if thumbnail is not None:
+            thumb_value = [int(thumbnail[0]), int(thumbnail[1])]
+        cmd_args = self._build_command_args(
+            "image_data",
+            {
+                "image_data": bytes(data),
+                "image_format": image_format,
+                "name": name,
+                "thumbnail": thumb_value,
+                "replica_name": replica_name,
+            },
+        )
+        if not self.connected:
+            self.open(create=True, truncate=False)
+        add_image_data(cmd_args, self.cur, self.con)
+
     def delete_uuid(self, uuid: str):
         if not self.connected:
             self.open(create=True, truncate=False)
@@ -282,6 +312,122 @@ class Manager:  # pylint: disable=too-many-public-methods
             self.open(create=True, truncate=False)
         add_time_series(cmd_args, self.cur, self.con)
 
+    def visualization_sequence(
+        self,
+        name: str,
+        vis_type: str,
+        variables,
+        items,
+        source_dataset: str | None = None,
+        thumbnail_name: str | None = None,
+        thumbnail_uuid: str | None = None,
+        metadata=None,
+        replace: bool = False,
+    ) -> int:
+        cmd_args = self._build_command_args(
+            "visualization_sequence",
+            {
+                "name": name,
+                "vis_type": vis_type,
+                "variables": variables,
+                "items": items,
+                "source_dataset": source_dataset,
+                "thumbnail_name": thumbnail_name,
+                "thumbnail_uuid": thumbnail_uuid,
+                "metadata": metadata,
+                "replace": replace,
+            },
+        )
+        if not self.connected:
+            self.open(create=True, truncate=False)
+        return add_visualization_sequence(cmd_args, self.cur, self.con)
+
+    def visualization(
+        self,
+        images,
+        vis_type: str | None = None,
+        variables=None,
+        source_dataset: str | None = None,
+        name: str | None = None,
+        sequence_name: str | None = None,
+        image_names: str | list[str] | None = None,
+        steps: list[int] | tuple[int, ...] | None = None,
+        image_format: str | None = None,
+        thumbnail: list[int] | tuple[int, int] | None = None,
+        thumbnail_image: int = 0,
+        store: bool = False,
+        metadata=None,
+        replace: bool = False,
+        kind: str | None = None,
+        variable: str | None = None,
+        color_by: str | None = None,
+        contour_by: str | None = None,
+        streamline_by=None,
+        x_axis: str | None = None,
+        y_axis=None,
+    ) -> int:
+        image_inputs = self._normalize_visualization_images(images)
+        if not image_inputs:
+            raise ValueError("visualization requires at least one image")
+
+        resolved_vis_type = self._resolve_visualization_kind(kind, vis_type)
+        variable_specs = self._build_visualization_variable_specs(
+            variables=variables,
+            variable=variable,
+            color_by=color_by,
+            contour_by=contour_by,
+            streamline_by=streamline_by,
+            x_axis=x_axis,
+            y_axis=y_axis,
+            source_dataset=source_dataset,
+        )
+        sequence_name = self._resolve_visualization_sequence_name(
+            source_dataset=source_dataset,
+            name=name,
+            sequence_name=sequence_name,
+            variables=variable_specs,
+        )
+        logical_image_names = self._resolve_visualization_image_names(
+            image_inputs=image_inputs,
+            sequence_name=sequence_name,
+            image_names=image_names,
+            steps=steps,
+            image_format=image_format,
+        )
+
+        if not 0 <= int(thumbnail_image) < len(image_inputs):
+            raise ValueError("thumbnail_image index is out of range")
+
+        for idx, image_input in enumerate(image_inputs):
+            logical_name = logical_image_names[idx]
+            if self._is_path_like_image(image_input):
+                self.image(
+                    str(image_input),
+                    name=logical_name,
+                    store=store,
+                    thumbnail=thumbnail,
+                )
+            else:
+                image_bytes, resolved_format = self._coerce_image_input(image_input, image_format)
+                self.image_data(
+                    image_bytes,
+                    resolved_format,
+                    name=logical_name,
+                    thumbnail=thumbnail,
+                    replica_name=f"generated/{Path(logical_name).name}",
+                )
+
+        return self.visualization_sequence(
+            name=sequence_name,
+            vis_type=resolved_vis_type,
+            variables=variable_specs,
+            items=[{"type": "IMAGE", "name": logical_name} for logical_name in logical_image_names],
+            source_dataset=source_dataset,
+            thumbnail_name=logical_image_names[int(thumbnail_image)],
+            metadata=metadata,
+            replace=replace,
+        )
+
     def upgrade(self) -> str:
         if not self.connected:
             self.open(create=True, truncate=False)
@@ -292,6 +438,233 @@ class Manager:  # pylint: disable=too-many-public-methods
         if isinstance(files, (str, Path)):
             return [str(files)]
         return [str(entry) for entry in files]
+
+    def _normalize_visualization_images(self, images):
+        if isinstance(images, (str, Path, bytes, bytearray, memoryview, PILImage.Image)):
+            return [images]
+        if self._is_matplotlib_figure(images):
+            return [images]
+        return list(images)
+
+    def _is_path_like_image(self, image) -> bool:
+        return isinstance(image, (str, Path))
+
+    def _is_matplotlib_figure(self, image) -> bool:
+        image_type = type(image)
+        return image_type.__module__.startswith("matplotlib.") and hasattr(image, "savefig")
+
+    def _infer_image_format(self, data: bytes) -> str | None:
+        if data.startswith(b"\x89PNG\r\n\x1a\n"):
+            return "PNG"
+        if data.startswith(b"\xff\xd8\xff"):
+            return "JPEG"
+        if data.startswith(b"GIF87a") or data.startswith(b"GIF89a"):
+            return "GIF"
+        return None
+
+    def _coerce_image_input(self, image, image_format: str | None) -> tuple[bytes, str]:
+        if isinstance(image, memoryview):
+            image = image.tobytes()
+        if isinstance(image, bytearray):
+            image = bytes(image)
+        if isinstance(image, bytes):
+            resolved_format = image_format or self._infer_image_format(image)
+            if not resolved_format:
+                raise ValueError("image_format is required for unrecognized in-memory image bytes")
+            return image, resolved_format
+        if isinstance(image, PILImage.Image):
+            if not image_format:
+                image_format = "PNG"
+            buf = BytesIO()
+            image.save(buf, format=image_format.upper())
+            return buf.getvalue(), image_format
+        if self._is_matplotlib_figure(image):
+            resolved_format = image_format or "PNG"
+            buf = BytesIO()
+            image.savefig(buf, format=resolved_format.lower())
+            return buf.getvalue(), resolved_format
+        raise TypeError(f"Unsupported visualization image input type: {type(image)!r}")
+
+    def _normalize_visualization_variable_specs(self, variables, source_dataset: str | None):
+        if isinstance(variables, (str, dict, tuple)):
+            variable_list = [variables]
+        else:
+            variable_list = list(variables)
+        normalized = []
+        default_source_dataset = source_dataset or ""
+        for entry in variable_list:
+            if isinstance(entry, str):
+                normalized.append({"name": entry, "role": "primary", "source_dataset": default_source_dataset})
+                continue
+            if isinstance(entry, dict):
+                item = dict(entry)
+                if "source_dataset" not in item or not item.get("source_dataset"):
+                    item["source_dataset"] = default_source_dataset
+                if ("role" not in item or not item.get("role")) and item.get("use"):
+                    item["role"] = item["use"]
+                if "role" not in item or not item.get("role"):
+                    item["role"] = "primary"
+                normalized.append(item)
+                continue
+            if isinstance(entry, tuple):
+                if len(entry) == 0:
+                    continue
+                item = {"name": entry[0], "role": "primary", "source_dataset": default_source_dataset}
+                if len(entry) >= 2 and entry[1]:
+                    item["role"] = entry[1]
+                if len(entry) >= 3 and entry[2]:
+                    item["source_dataset"] = entry[2]
+                normalized.append(item)
+                continue
+            raise TypeError(f"Unsupported variable specification: {entry!r}")
+        if not normalized:
+            raise ValueError("visualization requires at least one variable specification")
+        for item in normalized:
+            if not item.get("source_dataset"):
+                raise ValueError(f"Variable {item.get('name')!r} requires source_dataset")
+        return normalized
+
+    def _resolve_visualization_kind(self, kind: str | None, vis_type: str | None) -> str:
+        if kind and vis_type and kind != vis_type:
+            raise ValueError("visualization received both kind and vis_type with different values")
+        return str(kind or vis_type or "visualization")
+
+    def _semantic_variable_specs(
+        self,
+        variable: str | None,
+        color_by: str | None,
+        contour_by: str | None,
+        streamline_by,
+        x_axis: str | None,
+        y_axis,
+    ) -> list[dict[str, str]]:
+        specs: list[dict[str, str]] = []
+        if variable:
+            specs.append({"name": str(variable), "role": "primary"})
+        if color_by:
+            specs.append({"name": str(color_by), "role": "color-by"})
+        if contour_by:
+            specs.append({"name": str(contour_by), "role": "contour-by"})
+        if streamline_by:
+            if isinstance(streamline_by, (str, Path)):
+                specs.append({"name": str(streamline_by), "role": "streamline-by"})
+            else:
+                names = [str(entry) for entry in streamline_by]
+                if len(names) == 2:
+                    specs.append({"name": names[0], "role": "streamline-x"})
+                    specs.append({"name": names[1], "role": "streamline-y"})
+                else:
+                    for name in names:
+                        specs.append({"name": name, "role": "streamline-by"})
+        if x_axis:
+            specs.append({"name": str(x_axis), "role": "x-axis"})
+        if y_axis:
+            if isinstance(y_axis, (str, Path)):
+                y_names = [str(y_axis)]
+            else:
+                y_names = [str(entry) for entry in y_axis]
+            for name in y_names:
+                specs.append({"name": name, "role": "y-axis"})
+        return specs
+
+    def _build_visualization_variable_specs(
+        self,
+        variables,
+        variable: str | None,
+        color_by: str | None,
+        contour_by: str | None,
+        streamline_by,
+        x_axis: str | None,
+        y_axis,
+        source_dataset: str | None,
+    ):
+        semantic_specs = self._semantic_variable_specs(variable, color_by, contour_by, streamline_by, x_axis, y_axis)
+        if variables is not None and semantic_specs:
+            raise ValueError("Use either variables=... or semantic arguments, not both")
+        variable_inputs = variables if variables is not None else semantic_specs
+        return self._normalize_visualization_variable_specs(variable_inputs, source_dataset)
+
+    def _default_visualization_token(self, variables) -> str:
+        if len(variables) == 1 and variables[0]["role"] == "primary":
+            return str(variables[0]["name"])
+        parts = [f"{entry['role']}-{entry['name']}" for entry in variables]
+        return "__".join(parts)
+
+    def _default_visualization_name(self, source_dataset: str | None, variables) -> str:
+        root = source_dataset
+        if not root:
+            root = variables[0]["source_dataset"]
+        if not root:
+            root = "visualization"
+        return f"{root}/visualizations/{self._default_visualization_token(variables)}"
+
+    def _resolve_visualization_sequence_name(
+        self,
+        source_dataset: str | None,
+        name: str | None,
+        sequence_name: str | None,
+        variables,
+    ) -> str:
+        if name and sequence_name:
+            raise ValueError("Use either name or sequence_name, not both")
+        if sequence_name:
+            return str(sequence_name)
+        if not name:
+            return self._default_visualization_name(source_dataset, variables)
+        if "/" in str(name):
+            return str(name)
+        root = source_dataset or variables[0]["source_dataset"] or "visualization"
+        return f"{root}/visualizations/{name}"
+
+    def _resolve_visualization_image_names(
+        self,
+        image_inputs,
+        sequence_name: str,
+        image_names,
+        steps,
+        image_format: str | None,
+    ) -> list[str]:
+        if image_names is not None:
+            if isinstance(image_names, (str, Path)):
+                names = [str(image_names)]
+            else:
+                names = [str(entry) for entry in image_names]
+            if len(names) != len(image_inputs):
+                raise ValueError("image_names length must match number of images")
+            return names
+
+        if steps is not None:
+            step_values = [int(step) for step in steps]
+            if len(step_values) != len(image_inputs):
+                raise ValueError("steps length must match number of images")
+        else:
+            step_values = list(range(len(image_inputs)))
+
+        generated: list[str] = []
+        for step, image_input in zip(step_values, image_inputs, strict=True):
+            suffix = self._guess_image_suffix(image_input, image_format)
+            generated.append(f"{sequence_name}/image.{step:06d}{suffix}")
+        return generated
+
+    def _guess_image_suffix(self, image_input, image_format: str | None) -> str:
+        if isinstance(image_input, Path):
+            suffix = image_input.suffix
+            if suffix:
+                return suffix
+        if isinstance(image_input, str):
+            suffix = Path(image_input).suffix
+            if suffix:
+                return suffix
+        if image_format:
+            return "." + image_format.lower().lstrip(".")
+        if isinstance(image_input, (bytes, bytearray, memoryview)):
+            data = bytes(image_input)
+            inferred = self._infer_image_format(data)
+            if inferred == "JPEG":
+                return ".jpg"
+            if inferred:
+                return "." + inferred.lower()
+        return ".png"
 
 
 # pylint:disable = too-many-statements

--- a/hpc_campaign/manager_funcs.py
+++ b/hpc_campaign/manager_funcs.py
@@ -10,12 +10,14 @@
 import argparse
 import csv
 import glob
+import json
 import re
 import sqlite3
 import sys
 import uuid
 import zlib
 from hashlib import sha1
+from io import BytesIO
 from os import chdir, getcwd, remove, stat
 from os.path import basename, exists, isdir, join
 from pathlib import Path
@@ -319,6 +321,259 @@ def add_resolution_to_archive(
     return row_id
 
 
+def ensure_visualization_tables(cur: sqlite3.Cursor, con: sqlite3.Connection):
+    sql_execute(
+        cur,
+        "create table if not exists visualization_sequence"
+        + "(visid INTEGER PRIMARY KEY, name TEXT UNIQUE, vistype TEXT, thumbnail_itemuuid TEXT, metadata TEXT)",
+    )
+    sql_execute(
+        cur,
+        "create table if not exists visualization_variable"
+        + " (visid INT, datasetid INT, variable_name TEXT, role TEXT, "
+        + "PRIMARY KEY (visid, datasetid, variable_name, role))",
+    )
+    sql_execute(
+        cur,
+        "create table if not exists visualization_item"
+        + " (visid INT, item_order INT, item_type TEXT, item_uuid TEXT, metadata TEXT, "
+        + "PRIMARY KEY (visid, item_order))",
+    )
+    sql_commit(con)
+
+
+def _serialize_visualization_metadata(metadata) -> str | None:
+    if metadata is None:
+        return None
+    if isinstance(metadata, str):
+        metadata_str = metadata.strip()
+        return metadata_str or None
+    return json.dumps(metadata, sort_keys=True)
+
+
+def _resolve_live_dataset(cur: sqlite3.Cursor, dataset_name: str) -> tuple[int, str, str]:
+    res = sql_execute(
+        cur,
+        "select rowid, uuid, fileformat from dataset where name = ? and deltime = 0",
+        (dataset_name,),
+    )
+    row = res.fetchone()
+    if row is None:
+        raise LookupError(f"Dataset not found or deleted: {dataset_name}")
+    return int(row[0]), str(row[1]), str(row[2])
+
+
+def _resolve_live_dataset_by_uuid(cur: sqlite3.Cursor, dataset_uuid: str) -> tuple[int, str, str]:
+    res = sql_execute(
+        cur,
+        "select rowid, name, fileformat from dataset where uuid = ? and deltime = 0 order by rowid limit 1",
+        (dataset_uuid,),
+    )
+    row = res.fetchone()
+    if row is None:
+        raise LookupError(f"Dataset UUID not found or deleted: {dataset_uuid}")
+    return int(row[0]), str(row[1]), str(row[2])
+
+
+def _normalize_visualization_variable_specs(variables, default_source_dataset: str = "") -> list[dict[str, str]]:
+    if not variables:
+        raise ValueError("visualization_sequence requires at least one variable specification")
+
+    normalized: list[dict[str, str]] = []
+    for entry in variables:
+        variable_name = ""
+        role = "primary"
+        source_dataset_name = default_source_dataset
+
+        if isinstance(entry, str):
+            variable_name = entry.strip()
+        elif isinstance(entry, dict):
+            variable_name = str(entry.get("name", "") or "").strip()
+            role = str(entry.get("role", entry.get("use", "primary")) or "primary").strip()
+            source_dataset_name = str(
+                entry.get("source_dataset", default_source_dataset) or default_source_dataset
+            ).strip()
+        elif isinstance(entry, (list, tuple)):
+            if len(entry) == 0:
+                continue
+            variable_name = str(entry[0]).strip()
+            if len(entry) >= 2:
+                role = str(entry[1] or "primary").strip()
+            if len(entry) >= 3:
+                source_dataset_name = str(entry[2] or default_source_dataset).strip()
+        else:
+            raise ValueError(f"Unsupported visualization variable spec: {entry!r}")
+
+        if not variable_name:
+            raise ValueError(f"Invalid visualization variable spec without a name: {entry!r}")
+        if not role:
+            role = "primary"
+        if not source_dataset_name:
+            raise ValueError(
+                f"Visualization variable '{variable_name}' must specify source_dataset or use source_dataset=..."
+            )
+        normalized.append(
+            {
+                "name": variable_name,
+                "role": role,
+                "source_dataset": source_dataset_name,
+            }
+        )
+
+    if not normalized:
+        raise ValueError("visualization_sequence requires at least one variable specification")
+    return normalized
+
+
+def _normalize_visualization_items(items) -> list[dict[str, str | None]]:
+    if not items:
+        raise ValueError("visualization_sequence requires at least one item")
+
+    normalized: list[dict[str, str | None]] = []
+    for item in items:
+        item_type = "IMAGE"
+        item_uuid = ""
+        item_name = ""
+        item_metadata = None
+
+        if isinstance(item, str):
+            item_name = item.strip()
+        elif isinstance(item, dict):
+            item_type = str(item.get("type", "IMAGE") or "IMAGE").strip().upper()
+            item_uuid = str(item.get("uuid", "") or "").strip()
+            item_name = str(item.get("name", "") or "").strip()
+            item_metadata = _serialize_visualization_metadata(item.get("metadata"))
+        else:
+            raise ValueError(f"Unsupported visualization item spec: {item!r}")
+
+        if item_type != "IMAGE":
+            raise ValueError(f"Unsupported visualization item type: {item_type}. Only IMAGE is supported currently")
+        if not item_uuid and not item_name:
+            raise ValueError(f"Visualization item requires either name or uuid: {item!r}")
+        normalized.append(
+            {
+                "type": item_type,
+                "uuid": item_uuid or None,
+                "name": item_name or None,
+                "metadata": item_metadata,
+            }
+        )
+
+    return normalized
+
+
+def add_visualization_sequence(  # pylint: disable=too-many-statements
+    args: argparse.Namespace,
+    cur: sqlite3.Cursor,
+    con: sqlite3.Connection,
+) -> int:
+    ensure_visualization_tables(cur, con)
+
+    sequence_name = str(args.name or "").strip()
+    if not sequence_name:
+        raise ValueError("visualization_sequence requires a non-empty name")
+
+    vis_type = str(args.vis_type or "").strip()
+    if not vis_type:
+        raise ValueError("visualization_sequence requires a non-empty vis_type")
+
+    default_source_dataset = str(getattr(args, "source_dataset", "") or "").strip()
+    variable_specs = _normalize_visualization_variable_specs(args.variables, default_source_dataset)
+    item_specs = _normalize_visualization_items(args.items)
+
+    source_dataset_ids: dict[str, int] = {}
+    for variable_spec in variable_specs:
+        dataset_name = variable_spec["source_dataset"]
+        if dataset_name not in source_dataset_ids:
+            dataset_id, _dataset_uuid, _fileformat = _resolve_live_dataset(cur, dataset_name)
+            source_dataset_ids[dataset_name] = dataset_id
+
+    thumbnail_itemuuid = None
+    thumbnail_name = str(getattr(args, "thumbnail_name", "") or "").strip()
+    thumbnail_uuid = str(getattr(args, "thumbnail_uuid", "") or "").strip()
+    if thumbnail_uuid:
+        _thumb_id, _thumb_name, thumb_fileformat = _resolve_live_dataset_by_uuid(cur, thumbnail_uuid)
+        if thumb_fileformat != "IMAGE":
+            raise ValueError(f"thumbnail_uuid must refer to an IMAGE dataset, not {thumb_fileformat}")
+        thumbnail_itemuuid = thumbnail_uuid
+    elif thumbnail_name:
+        _thumb_id, thumbnail_itemuuid, thumb_fileformat = _resolve_live_dataset(cur, thumbnail_name)
+        if thumb_fileformat != "IMAGE":
+            raise ValueError(f"thumbnail_name must refer to an IMAGE dataset, not {thumb_fileformat}")
+
+    resolved_items: list[dict[str, str | None]] = []
+    for item_spec in item_specs:
+        item_uuid = item_spec["uuid"]
+        item_name = item_spec["name"]
+        if item_uuid:
+            _item_id, _resolved_name, item_fileformat = _resolve_live_dataset_by_uuid(cur, str(item_uuid))
+        else:
+            _item_id, item_uuid, item_fileformat = _resolve_live_dataset(cur, str(item_name))
+        if item_fileformat != "IMAGE":
+            raise ValueError(f"Visualization item must refer to an IMAGE dataset, not {item_fileformat}")
+        resolved_items.append(
+            {
+                "type": str(item_spec["type"]),
+                "uuid": str(item_uuid),
+                "metadata": item_spec["metadata"],
+            }
+        )
+
+    metadata_text = _serialize_visualization_metadata(args.metadata)
+
+    res = sql_execute(cur, "select visid from visualization_sequence where name = ?", (sequence_name,))
+    row = res.fetchone()
+    visid = None
+    if row is not None:
+        visid = int(row[0])
+        if not args.replace:
+            raise ValueError(f"Visualization sequence already exists: {sequence_name}")
+        sql_execute(
+            cur,
+            "update visualization_sequence set vistype = ?, thumbnail_itemuuid = ?, metadata = ? where visid = ?",
+            (vis_type, thumbnail_itemuuid, metadata_text, visid),
+        )
+        sql_execute(cur, "delete from visualization_variable where visid = ?", (visid,))
+        sql_execute(cur, "delete from visualization_item where visid = ?", (visid,))
+    else:
+        cur_vis = sql_execute(
+            cur,
+            "insert into visualization_sequence (name, vistype, thumbnail_itemuuid, metadata) "
+            "values (?, ?, ?, ?) returning visid",
+            (sequence_name, vis_type, thumbnail_itemuuid, metadata_text),
+        )
+        visid = int(cur_vis.fetchone()[0])
+
+    for variable_spec in variable_specs:
+        source_dataset_name = variable_spec["source_dataset"]
+        sql_execute(
+            cur,
+            "insert into visualization_variable (visid, datasetid, variable_name, role) values (?, ?, ?, ?)",
+            (
+                visid,
+                source_dataset_ids[source_dataset_name],
+                variable_spec["name"],
+                variable_spec["role"],
+            ),
+        )
+
+    for item_order, item_spec in enumerate(resolved_items):
+        sql_execute(
+            cur,
+            "insert into visualization_item (visid, item_order, item_type, item_uuid, metadata) values (?, ?, ?, ?, ?)",
+            (
+                visid,
+                item_order,
+                item_spec["type"],
+                item_spec["uuid"],
+                item_spec["metadata"],
+            ),
+        )
+
+    sql_commit(con)
+    return visid
+
+
 def process_data(
     args: argparse.Namespace,
     cur: sqlite3.Cursor,
@@ -489,7 +744,7 @@ def process_image(
                 dir_id,
                 0,
                 key_id,
-                join("thumbnails", args.file),
+                join("thumbnails", args.file.lstrip("/")),
                 cur,
                 ds_id,
                 now,
@@ -508,6 +763,95 @@ def process_image(
             )
             add_resolution_to_archive(thumb_rep_id, imgres[0], imgres[1], cur, indent="  ")
             remove(thumbfilename)
+
+
+def process_image_data(
+    args: argparse.Namespace,
+    cur: sqlite3.Cursor,
+    host_id: int,
+    dir_id: int,
+    key_id: int,
+    dirpath: str,
+    location: str,
+):
+    image_bytes = bytes(args.image_data)
+    image_format = str(args.image_format or "").strip()
+    if not image_format:
+        raise ValueError("image_data requires image_format")
+
+    suffix = "." + image_format.lower().lstrip(".")
+    if args.name is not None:
+        dataset = args.name
+        unique_id = uuid.uuid3(uuid.NAMESPACE_URL, location + "/" + dataset).hex
+    else:
+        checksum = sha1(image_bytes).hexdigest()
+        unique_id = uuid.uuid5(uuid.NAMESPACE_OID, checksum).hex
+        dataset = f"memory-images/image-{unique_id[:12]}{suffix}"
+
+    replica_name = getattr(args, "replica_name", "") or join("memory-images", f"{unique_id}{suffix}")
+
+    mt = time_ns()
+    filesize = len(image_bytes)
+    print(f"Process in-memory image {dataset}")
+
+    img = Image.open(BytesIO(image_bytes))
+    img.load()
+    imgres = img.size
+
+    ds_id = add_dataset_to_archive(dataset, cur, unique_id, "IMAGE", mt, indent="  ")
+    rep_id = add_replica_to_archive(host_id, dir_id, 0, key_id, replica_name, cur, ds_id, mt, filesize, indent="  ")
+    add_resolution_to_archive(rep_id, imgres[0], imgres[1], cur, indent="  ")
+
+    resname = f"{imgres[0]}x{imgres[1]}{suffix}"
+    add_file_to_archive(args, "", cur, rep_id, mt, resname, compress=False, content=image_bytes, indent="  ")
+
+    if args.thumbnail is not None:
+        print(f"  Make thumbnail image with resolution {args.thumbnail}")
+        thumb_img = img.copy()
+        thumb_img.thumbnail(args.thumbnail)
+        thumb_res = thumb_img.size
+        thumb_buffer = BytesIO()
+        thumb_img.save(thumb_buffer, format=image_format.upper())
+        thumb_bytes = thumb_buffer.getvalue()
+        thumb_now = time_ns()
+        thumb_rep_id = add_replica_to_archive(
+            host_id,
+            dir_id,
+            0,
+            key_id,
+            join("thumbnails", replica_name),
+            cur,
+            ds_id,
+            thumb_now,
+            len(thumb_bytes),
+            indent="  ",
+        )
+        thumb_resname = f"{thumb_res[0]}x{thumb_res[1]}{suffix}"
+        add_file_to_archive(
+            args,
+            "",
+            cur,
+            thumb_rep_id,
+            thumb_now,
+            thumb_resname,
+            compress=False,
+            content=thumb_bytes,
+            indent="  ",
+        )
+        add_resolution_to_archive(thumb_rep_id, thumb_res[0], thumb_res[1], cur, indent="  ")
+
+
+def add_image_data(args: argparse.Namespace, cur: sqlite3.Cursor, con: sqlite3.Connection):
+    long_host_name, short_host_name = get_host_name(args)
+
+    host_id = add_host_name(long_host_name, short_host_name, cur)
+    key_id = add_key_id(args.encryption_key_id, cur)
+    rootdir = getcwd()
+    dir_id = add_directory(host_id, rootdir, cur)
+    sql_commit(con)
+
+    process_image_data(args, cur, host_id, dir_id, key_id, long_host_name + rootdir, rootdir)
+    sql_commit(con)
 
 
 # pylint: disable=too-many-statements
@@ -1128,6 +1472,7 @@ def create_tables(campaign_file_name: str, con: sqlite3.Connection):
         cur,
         "create table archive" + "(dirid INT, tarname TEXT,system TEXT, notes BLOB, PRIMARY KEY (dirid, tarname))",
     )
+    ensure_visualization_tables(cur, con)
     sql_execute(
         cur,
         "create table archiveidx"

--- a/tests/test_adios_image_ingest.py
+++ b/tests/test_adios_image_ingest.py
@@ -1,0 +1,190 @@
+from pathlib import Path
+
+import adios2
+import matplotlib
+import numpy as np
+
+from hpc_campaign.manager import Manager
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+
+
+def make_scalar_fields(nx: int, ny: int, step: int) -> dict[str, np.ndarray]:
+    x = np.linspace(0.0, 2.0 * np.pi, nx, endpoint=False)
+    y = np.linspace(0.0, 2.0 * np.pi, ny, endpoint=False)
+    xx, yy = np.meshgrid(x, y, indexing="ij")
+
+    field_a = np.sin(xx + 0.3 * step) * np.cos(yy)
+    field_b = xx + 0.5 * yy + float(step)
+    return {
+        "field_a": field_a.astype(np.float64),
+        "field_b": field_b.astype(np.float64),
+    }
+
+
+def write_adios_dataset(output_path: Path, nsteps: int = 3, nx: int = 16, ny: int = 16) -> None:
+    with adios2.Stream(str(output_path), "w") as stream:
+        for step in range(nsteps):
+            stream.begin_step()
+            for name, data in make_scalar_fields(nx, ny, step).items():
+                stream.write(name, data, data.shape, [0, 0], data.shape)
+            stream.end_step()
+
+
+def render_images(dataset_path: Path, images_root: Path) -> list[tuple[Path, str]]:
+    rendered_images: list[tuple[Path, str]] = []
+    with adios2.Stream(str(dataset_path), "r") as stream:
+        for _ in stream.steps():
+            step = stream.current_step()
+            for field_name, cmap in (("field_a", "viridis"), ("field_b", "magma")):
+                image_dir = images_root / field_name / "heatmap"
+                image_dir.mkdir(parents=True, exist_ok=True)
+                image_path = image_dir / f"image.{step:06d}.png"
+                data = np.squeeze(stream.read(field_name))
+                plt.imsave(image_path, data, cmap=cmap, origin="lower")
+                print(f"rendered image: {image_path.resolve()}")
+                rendered_images.append((image_path, field_name))
+    return rendered_images
+
+
+def add_field_visualization_sequences(manager: Manager, rendered_images: list[tuple[Path, str]]) -> None:
+    for field_name in ("field_a", "field_b"):
+        logical_names = [
+            f"synthetic.bp/{field_name}/images/heatmap/{image_path.name}"
+            for image_path, image_field_name in rendered_images
+            if image_field_name == field_name
+        ]
+        manager.visualization_sequence(
+            name=f"synthetic.bp/{field_name}/images/heatmap",
+            vis_type="heatmap",
+            variables=[
+                {
+                    "name": field_name,
+                    "role": "primary",
+                    "source_dataset": "synthetic.bp",
+                }
+            ],
+            items=[{"type": "IMAGE", "name": logical_name} for logical_name in logical_names],
+            thumbnail_name=logical_names[0],
+        )
+
+
+def find_sequence(visualization_sequences, name: str):
+    return next(sequence for sequence in visualization_sequences.values() if sequence.name == name)
+
+
+def test_adios_images(tmp_path: Path):
+    archive_name = "adios_images.aca"
+    dataset_path = tmp_path / "synthetic.bp"
+    images_root = tmp_path / "rendered"
+    archive_path = tmp_path / archive_name
+
+    # Build a small time-varying ADIOS dataset with two scalar fields.
+    write_adios_dataset(dataset_path, nsteps=3, nx=64, ny=64)
+
+    # Render one PNG per field per timestep using Python-only tooling so the
+    # test remains self-contained and CI-friendly.
+    rendered_images = render_images(dataset_path, images_root)
+    assert len(rendered_images) == 6
+
+    print(f"campaign file: {archive_path.resolve()}")
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(dataset_path), name="synthetic.bp")
+
+    for image_path, field_name in rendered_images:
+        logical_name = f"synthetic.bp/{field_name}/images/heatmap/{image_path.name}"
+        manager.image(str(image_path), name=logical_name)
+
+    add_field_visualization_sequences(manager, rendered_images)
+
+    info_data = manager.info()
+    datasets = list(info_data.datasets.values())
+    adios_datasets = [dataset for dataset in datasets if dataset.file_format == "ADIOS"]
+    image_datasets = [dataset for dataset in datasets if dataset.file_format == "IMAGE"]
+    visualization_sequences = info_data.visualization_sequences
+
+    assert len(adios_datasets) == 1
+    assert adios_datasets[0].name == "synthetic.bp"
+    assert len(image_datasets) == 6
+    assert len(visualization_sequences) == 2
+
+    expected_image_names = {f"synthetic.bp/field_a/images/heatmap/image.{step:06d}.png" for step in range(3)} | {
+        f"synthetic.bp/field_b/images/heatmap/image.{step:06d}.png" for step in range(3)
+    }
+    assert {dataset.name for dataset in image_datasets} == expected_image_names
+
+    field_a_sequence = find_sequence(visualization_sequences, "synthetic.bp/field_a/images/heatmap")
+    assert field_a_sequence.vis_type == "heatmap"
+    assert field_a_sequence.thumbnail_dataset_name == "synthetic.bp/field_a/images/heatmap/image.000000.png"
+    assert len(field_a_sequence.items) == 3
+    assert field_a_sequence.variables[0].name == "field_a"
+    assert field_a_sequence.variables[0].source_dataset_name == "synthetic.bp"
+
+    field_b_sequence = find_sequence(visualization_sequences, "synthetic.bp/field_b/images/heatmap")
+    assert field_b_sequence.vis_type == "heatmap"
+    assert field_b_sequence.thumbnail_dataset_name == "synthetic.bp/field_b/images/heatmap/image.000000.png"
+    assert len(field_b_sequence.items) == 3
+    assert field_b_sequence.variables[0].name == "field_b"
+    assert field_b_sequence.variables[0].source_dataset_name == "synthetic.bp"
+
+    manager.close()
+
+
+def test_adios_image_bytes(tmp_path: Path):
+    archive_name = "adios_image_bytes.aca"
+    dataset_path = tmp_path / "synthetic.bp"
+    images_root = tmp_path / "rendered"
+    archive_path = tmp_path / archive_name
+
+    # Reuse the same synthetic ADIOS dataset and rendered PNGs, but ingest the
+    # images from in-memory bytes rather than from filesystem paths.
+    write_adios_dataset(dataset_path, nsteps=3, nx=64, ny=64)
+    rendered_images = render_images(dataset_path, images_root)
+    assert len(rendered_images) == 6
+
+    print(f"campaign file: {archive_path.resolve()}")
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(dataset_path), name="synthetic.bp")
+
+    for image_path, field_name in rendered_images:
+        logical_name = f"synthetic.bp/{field_name}/images/heatmap/{image_path.name}"
+        manager.image_data(image_path.read_bytes(), image_format="PNG", name=logical_name)
+
+    add_field_visualization_sequences(manager, rendered_images)
+
+    info_data = manager.info(list_replicas=True)
+    datasets = list(info_data.datasets.values())
+    adios_datasets = [dataset for dataset in datasets if dataset.file_format == "ADIOS"]
+    image_datasets = [dataset for dataset in datasets if dataset.file_format == "IMAGE"]
+    visualization_sequences = info_data.visualization_sequences
+
+    assert len(adios_datasets) == 1
+    assert adios_datasets[0].name == "synthetic.bp"
+    assert len(image_datasets) == 6
+    assert len(visualization_sequences) == 2
+
+    expected_image_names = {f"synthetic.bp/field_a/images/heatmap/image.{step:06d}.png" for step in range(3)} | {
+        f"synthetic.bp/field_b/images/heatmap/image.{step:06d}.png" for step in range(3)
+    }
+    assert {dataset.name for dataset in image_datasets} == expected_image_names
+    assert all(any(replica.flags.embedded for replica in dataset.replicas.values()) for dataset in image_datasets)
+
+    field_a_sequence = find_sequence(visualization_sequences, "synthetic.bp/field_a/images/heatmap")
+    assert field_a_sequence.vis_type == "heatmap"
+    assert field_a_sequence.thumbnail_dataset_name == "synthetic.bp/field_a/images/heatmap/image.000000.png"
+    assert len(field_a_sequence.items) == 3
+    assert field_a_sequence.variables[0].name == "field_a"
+    assert field_a_sequence.variables[0].source_dataset_name == "synthetic.bp"
+
+    field_b_sequence = find_sequence(visualization_sequences, "synthetic.bp/field_b/images/heatmap")
+    assert field_b_sequence.vis_type == "heatmap"
+    assert field_b_sequence.thumbnail_dataset_name == "synthetic.bp/field_b/images/heatmap/image.000000.png"
+    assert len(field_b_sequence.items) == 3
+    assert field_b_sequence.variables[0].name == "field_b"
+    assert field_b_sequence.variables[0].source_dataset_name == "synthetic.bp"
+
+    manager.close()

--- a/tests/test_visualization_sequence.py
+++ b/tests/test_visualization_sequence.py
@@ -1,0 +1,336 @@
+from pathlib import Path
+
+from PIL import Image
+
+from hpc_campaign.info import format_info
+from hpc_campaign.manager import Manager
+
+repo_root = Path(__file__).resolve().parents[1]
+data_dir = repo_root / "data"
+
+
+def test_visualization_sequence_single_source(tmp_path: Path):
+    archive_name = "visualization_single.aca"
+    image_path = tmp_path / "thumb.png"
+    Image.new("RGB", (8, 8), color="blue").save(image_path)
+    print(f"tmp_path={tmp_path}")
+
+    # Create a tiny campaign with one source dataset and one image that will
+    # act as the sequence thumbnail and only item.
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(data_dir / "onearray.h5"), name="output")
+    manager.image(str(image_path), name="thumb")
+
+    # Register one visualization sequence. The source dataset is implicit for
+    # variables unless they override it, and the sequence items are explicit
+    # image references rather than a frame-pattern string.
+    visid = manager.visualization_sequence(
+        name="output/temp_heatmap",
+        vis_type="heatmap",
+        source_dataset="output",
+        variables=[{"name": "temp", "role": "primary"}],
+        items=[{"type": "IMAGE", "name": "thumb"}],
+        thumbnail_name="thumb",
+        metadata={"colormap": "viridis"},
+    )
+
+    assert visid > 0
+
+    # Read the archive back through info() and verify that the sequence-level
+    # metadata, variable association, thumbnail, and explicit item were stored.
+    info_data = manager.info()
+    assert len(info_data.visualization_sequences) == 1
+
+    sequence_info = next(iter(info_data.visualization_sequences.values()))
+    assert sequence_info.name == "output/temp_heatmap"
+    assert sequence_info.vis_type == "heatmap"
+    assert sequence_info.thumbnail_dataset_name == "thumb"
+    assert len(sequence_info.variables) == 1
+    assert sequence_info.variables[0].name == "temp"
+    assert sequence_info.variables[0].role == "primary"
+    assert sequence_info.variables[0].source_dataset_name == "output"
+    assert sequence_info.metadata == '{"colormap": "viridis"}'
+    assert len(sequence_info.items) == 1
+    assert sequence_info.items[0].item_type == "IMAGE"
+    assert sequence_info.items[0].dataset_name == "thumb"
+    assert sequence_info.items[0].item_uuid == sequence_info.thumbnail_item_uuid
+
+    # format_info() should expose the new visualization section in human-
+    # readable output, not just in the structured InfoResult object.
+    output_text = format_info(info_data)
+    assert "Visualization Sequences:" in output_text
+    assert "output/temp_heatmap   type=heatmap" in output_text
+    assert "primary: temp (dataset output)" in output_text
+    assert "items: 1 (IMAGE)" in output_text
+
+    manager.close()
+
+
+def test_visualization_sequence_multi_source_with_thumbnail(tmp_path: Path):
+    archive_name = "visualization_multi.aca"
+    image_path = tmp_path / "thumbnail.png"
+    Image.new("RGB", (8, 8), color="red").save(image_path)
+    print(f"tmp_path={tmp_path}")
+
+    # Create two source datasets so the sequence can reference variables from
+    # different inputs, plus one image that the sequence will point at.
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(data_dir / "onearray.h5"), name="output_a")
+    manager.data(str(data_dir / "onearray.h5"), name="output_b")
+    manager.image(str(image_path), name="thumb")
+
+    # Initial definition: one sequence, two variables from different datasets,
+    # and one IMAGE item referenced by dataset name.
+    visid = manager.visualization_sequence(
+        name="output/overlay",
+        vis_type="overlay",
+        variables=[
+            {"name": "rho", "role": "background", "source_dataset": "output_a"},
+            {"name": "current_z", "role": "contour", "source_dataset": "output_b"},
+        ],
+        items=[{"type": "IMAGE", "name": "thumb"}],
+        thumbnail_name="thumb",
+        replace=False,
+    )
+
+    assert visid > 0
+
+    # Confirm the multi-dataset variable mapping and the explicit item link.
+    info_data = manager.info()
+    sequence_info = next(iter(info_data.visualization_sequences.values()))
+    assert sequence_info.thumbnail_dataset_name == "thumb"
+    assert [(entry.role, entry.name, entry.source_dataset_name) for entry in sequence_info.variables] == [
+        ("background", "rho", "output_a"),
+        ("contour", "current_z", "output_b"),
+    ]
+    assert len(sequence_info.items) == 1
+    assert sequence_info.items[0].dataset_name == "thumb"
+
+    # Replace the sequence definition in place. This exercises the update path:
+    # same sequence name/visid, changed vis_type and variable list, item
+    # referenced this time by UUID instead of dataset name.
+    updated_visid = manager.visualization_sequence(
+        name="output/overlay",
+        vis_type="heatmap_contour",
+        variables=[
+            {"name": "rho", "role": "background", "source_dataset": "output_a"},
+            {"name": "div_b", "role": "contour", "source_dataset": "output_b"},
+        ],
+        items=[{"type": "IMAGE", "uuid": sequence_info.items[0].item_uuid}],
+        thumbnail_uuid=sequence_info.items[0].item_uuid,
+        replace=True,
+    )
+
+    assert updated_visid == visid
+
+    # The sequence row should be updated in place and the old variable mapping
+    # should be replaced by the new one.
+    updated_info = manager.info()
+    updated_sequence = next(iter(updated_info.visualization_sequences.values()))
+    assert updated_sequence.vis_type == "heatmap_contour"
+    assert [(entry.role, entry.name, entry.source_dataset_name) for entry in updated_sequence.variables] == [
+        ("background", "rho", "output_a"),
+        ("contour", "div_b", "output_b"),
+    ]
+    assert len(updated_sequence.items) == 1
+    assert updated_sequence.items[0].dataset_name == "thumb"
+
+    manager.close()
+
+
+def test_visualization_single_file_convenience_api(tmp_path: Path):
+    archive_name = "visualization_convenience_single.aca"
+    image_path = tmp_path / "frame.png"
+    Image.new("RGB", (12, 10), color="purple").save(image_path)
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(data_dir / "onearray.h5"), name="output")
+
+    visid = manager.visualization(
+        images=str(image_path),
+        vis_type="heatmap",
+        source_dataset="output",
+        variables=[{"name": "temp", "role": "primary"}],
+        thumbnail=(6, 6),
+        metadata={"note": "auto-generated names"},
+    )
+
+    assert visid > 0
+
+    info_data = manager.info(list_replicas=True, list_files=True)
+    sequence_info = next(iter(info_data.visualization_sequences.values()))
+    assert sequence_info.name == "output/visualizations/temp"
+    assert len(sequence_info.items) == 1
+    assert sequence_info.items[0].dataset_name == "output/visualizations/temp/image.000000.png"
+    image_dataset = next(
+        dataset for dataset in info_data.datasets.values() if dataset.name == sequence_info.items[0].dataset_name
+    )
+    assert len(image_dataset.replicas) == 2
+
+    manager.close()
+
+
+def test_visualization_sequence_file_list_convenience_api(tmp_path: Path):
+    archive_name = "visualization_convenience_sequence.aca"
+    first_dir = tmp_path / "a"
+    second_dir = tmp_path / "b"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    image_path_a = first_dir / "image.000.png"
+    image_path_b = second_dir / "image.000.png"
+    Image.new("RGB", (8, 8), color="green").save(image_path_a)
+    Image.new("RGB", (8, 8), color="yellow").save(image_path_b)
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(data_dir / "onearray.h5"), name="output")
+
+    visid = manager.visualization(
+        images=[image_path_a, image_path_b],
+        vis_type="heatmap_contour",
+        source_dataset="output",
+        variables=[
+            {"name": "rho", "role": "background"},
+            {"name": "pressure", "role": "contour"},
+        ],
+    )
+
+    assert visid > 0
+
+    info_data = manager.info()
+    sequence_info = next(iter(info_data.visualization_sequences.values()))
+    assert len(sequence_info.items) == 2
+    expected_prefix = "output/visualizations/background-rho__contour-pressure"
+    assert sequence_info.items[0].dataset_name == f"{expected_prefix}/image.000000.png"
+    assert sequence_info.items[1].dataset_name == f"{expected_prefix}/image.000001.png"
+
+    manager.close()
+
+
+def test_visualization_in_memory_image_convenience_api(tmp_path: Path):
+    archive_name = "visualization_convenience_memory.aca"
+    image = Image.new("RGB", (10, 10), color="orange")
+    png_path = tmp_path / "memory.png"
+    image.save(png_path)
+    png_bytes = png_path.read_bytes()
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(data_dir / "onearray.h5"), name="output")
+
+    visid = manager.visualization(
+        images=png_bytes,
+        vis_type="heatmap",
+        source_dataset="output",
+        variables=[{"name": "temp", "role": "primary"}],
+        thumbnail=(4, 4),
+    )
+
+    assert visid > 0
+
+    info_data = manager.info(list_replicas=True, list_files=True)
+    sequence_info = next(iter(info_data.visualization_sequences.values()))
+    image_dataset = next(
+        dataset for dataset in info_data.datasets.values() if dataset.name == sequence_info.items[0].dataset_name
+    )
+    assert len(image_dataset.replicas) == 2
+    assert any(replica.flags.embedded for replica in image_dataset.replicas.values())
+
+    manager.close()
+
+
+def test_visualization_semantic_arguments_and_steps(tmp_path: Path):
+    archive_name = "visualization_semantic.aca"
+    image_path_a = tmp_path / "image_a.png"
+    image_path_b = tmp_path / "image_b.png"
+    image_path_c = tmp_path / "image_c.png"
+    Image.new("RGB", (8, 8), color="green").save(image_path_a)
+    Image.new("RGB", (8, 8), color="yellow").save(image_path_b)
+    Image.new("RGB", (8, 8), color="red").save(image_path_c)
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(data_dir / "onearray.h5"), name="output")
+
+    visid = manager.visualization(
+        images=[image_path_a, image_path_b],
+        kind="heatmap_contour",
+        source_dataset="output",
+        name="rho_current_overlay",
+        color_by="rho",
+        contour_by="current_z",
+        steps=[10, 20],
+    )
+
+    assert visid > 0
+
+    info_data = manager.info()
+    sequence_info = next(iter(info_data.visualization_sequences.values()))
+    assert sequence_info.name == "output/visualizations/rho_current_overlay"
+    assert sequence_info.vis_type == "heatmap_contour"
+    assert [(entry.role, entry.name, entry.source_dataset_name) for entry in sequence_info.variables] == [
+        ("color-by", "rho", "output"),
+        ("contour-by", "current_z", "output"),
+    ]
+    assert [item.dataset_name for item in sequence_info.items] == [
+        "output/visualizations/rho_current_overlay/image.000010.png",
+        "output/visualizations/rho_current_overlay/image.000020.png",
+    ]
+
+    updated_visid = manager.visualization(
+        images=image_path_c,
+        kind="heatmap",
+        source_dataset="output",
+        name="rho_current_overlay",
+        color_by="rho",
+        steps=[30],
+        replace=True,
+    )
+
+    assert updated_visid == visid
+    updated_info = manager.info()
+    updated_sequence = next(iter(updated_info.visualization_sequences.values()))
+    assert updated_sequence.vis_type == "heatmap"
+    assert [(entry.role, entry.name, entry.source_dataset_name) for entry in updated_sequence.variables] == [
+        ("color-by", "rho", "output"),
+    ]
+    assert [item.dataset_name for item in updated_sequence.items] == [
+        "output/visualizations/rho_current_overlay/image.000030.png",
+    ]
+
+    manager.close()
+
+
+def test_visualization_axis_semantics_and_exact_sequence_name(tmp_path: Path):
+    archive_name = "visualization_axes.aca"
+    image_path = tmp_path / "line.png"
+    Image.new("RGB", (8, 8), color="white").save(image_path)
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(data_dir / "onearray.h5"), name="output")
+
+    visid = manager.visualization(
+        images=image_path,
+        kind="line-plot",
+        source_dataset="output",
+        sequence_name="custom/sequence/name",
+        x_axis="time",
+        y_axis="mass",
+    )
+
+    assert visid > 0
+    info_data = manager.info()
+    sequence_info = next(iter(info_data.visualization_sequences.values()))
+    assert sequence_info.name == "custom/sequence/name"
+    assert sequence_info.vis_type == "line-plot"
+    assert [(entry.role, entry.name, entry.source_dataset_name) for entry in sequence_info.variables] == [
+        ("x-axis", "time", "output"),
+        ("y-axis", "mass", "output"),
+    ]
+    assert sequence_info.items[0].dataset_name == "custom/sequence/name/image.000000.png"
+
+    manager.close()

--- a/tools/print_campaign_entries.py
+++ b/tools/print_campaign_entries.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Print campaign entries and image association metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print campaign entries. Images include visualization association data."
+    )
+    parser.add_argument(
+        "campaign",
+        help="Campaign archive name or path to a .aca file.",
+    )
+    parser.add_argument(
+        "--campaign-store",
+        default="",
+        help="Campaign store directory when CAMPAIGN is not a full path.",
+    )
+    parser.add_argument(
+        "--show-deleted",
+        action="store_true",
+        help="Include deleted entries.",
+    )
+    return parser.parse_args()
+
+
+def resolve_archive(campaign: str, campaign_store: str) -> tuple[str, str]:
+    candidate = Path(campaign).expanduser()
+    if candidate.exists():
+        archive_path = candidate.resolve()
+        if archive_path.suffix != ".aca":
+            raise SystemExit(f"Expected a .aca file path, got: {archive_path}")
+        return archive_path.stem, str(archive_path.parent)
+    return campaign, campaign_store
+
+
+def collect_datasets(info_data) -> list:
+    datasets: list = []
+    for ts_info in info_data.time_series.values():
+        datasets.extend(ts_info.datasets.values())
+    datasets.extend(info_data.datasets.values())
+    datasets.sort(key=lambda dataset: (dataset.name, dataset.file_format, dataset.uuid))
+    return datasets
+
+
+def image_associations(
+    image_name: str,
+    sequences: list,
+) -> list[tuple[object, bool]]:
+    matches: list[tuple[object, bool]] = []
+    for sequence in sequences:
+        is_thumbnail = sequence.thumbnail_dataset_name == image_name
+        in_sequence = any(item.dataset_name == image_name for item in sequence.items if item.dataset_name is not None)
+        if is_thumbnail or in_sequence:
+            matches.append((sequence, is_thumbnail))
+    matches.sort(key=lambda item: item[0].name)
+    return matches
+
+
+def format_metadata(metadata: str | None) -> str | None:
+    if not metadata:
+        return None
+    try:
+        return json.dumps(json.loads(metadata), sort_keys=True)
+    except json.JSONDecodeError:
+        return metadata
+
+
+def main() -> None:
+    args = parse_args()
+    from hpc_campaign import Manager
+
+    archive, campaign_store = resolve_archive(args.campaign, args.campaign_store)
+
+    manager = Manager(archive=archive, campaign_store=campaign_store)
+    manager.open(create=False, truncate=False)
+    try:
+        info_data = manager.info(show_deleted=args.show_deleted)
+    finally:
+        manager.close()
+
+    sequences = list(info_data.visualization_sequences.values())
+    datasets = collect_datasets(info_data)
+
+    for dataset in datasets:
+        print(f"{dataset.name}: {dataset.file_format}")
+        if dataset.file_format != "IMAGE":
+            continue
+
+        associations = image_associations(dataset.name, sequences)
+        if not associations:
+            print("  associations: none")
+            continue
+
+        for sequence, is_thumbnail in associations:
+            print(f"  sequence: {sequence.name}")
+            print(f"    vis_type: {sequence.vis_type}")
+            if is_thumbnail:
+                print("    thumbnail: true")
+            if sequence.variables:
+                source_names: list[str] = []
+                for variable in sequence.variables:
+                    if variable.source_dataset_name not in source_names:
+                        source_names.append(variable.source_dataset_name)
+                sources = ", ".join(source_names)
+                print(f"    sources: {sources}")
+                variables = ", ".join(
+                    f"{variable.role}={variable.name}@{variable.source_dataset_name}" for variable in sequence.variables
+                )
+                print(f"    variables: {variables}")
+            item_uuids = ", ".join(item.item_uuid for item in sequence.items if item.dataset_name == dataset.name)
+            if item_uuids:
+                print(f"    item_uuid: {item_uuids}")
+            metadata = format_metadata(sequence.metadata)
+            if metadata:
+                print(f"    metadata: {metadata}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a higher-level visualization API to the Python interface while keeping the existing low-level campaign APIs intact. The new `Manager.visualization(...)` entry point accepts either a single image or a list of images, supports both file-backed and in-memory image inputs, auto-generates logical image names and sequence names when needed, and registers the associated visualization metadata using the `visualization_sequence`, `visualization_variable`, and `visualization_item` tables. It also adds `Manager.image_data(...)` so images generated in memory can be embedded directly into the campaign without first writing a temporary file.

In addition, the PR extends `info()` and related inspection tooling so the new visualization metadata can be read back cleanly, adds focused tests for both the low-level and convenience APIs, and fixes an existing thumbnail-replica bug for absolute image paths. It also adds new integration tests that generate a small time-varying ADIOS dataset, render per-field images, ingest those images both by file path and by in-memory bytes, and register visualization sequences for the resulting image sets. While adding that coverage, the PR also fixes an `image_data(...)` identity bug where distinct logical images with identical byte content could collapse onto the same dataset. The result is that users can still use the explicit `image(...)` and `visualization_sequence(...)` calls when they want full control, but now also have a simpler one-call path for common visualization ingestion workflows.