### PR TITLE
Add mhd example

### DIFF
--- a/examples/mhd_orszag_tang/CMakeLists.txt
+++ b/examples/mhd_orszag_tang/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.18)
+project(orszag_tang_mhd_adios LANGUAGES CXX)
+
+option(OT_ENABLE_MPI "Enable MPI domain decomposition" ON)
+
+find_package(ADIOS2 REQUIRED)
+
+if(OT_ENABLE_MPI)
+  find_package(MPI REQUIRED COMPONENTS CXX)
+endif()
+
+set(OT_SOURCES
+  src/main.cpp
+  src/mhd2d.cpp
+  src/adios_writer.cpp
+)
+
+add_executable(ot_mhd ${OT_SOURCES})
+target_include_directories(ot_mhd PRIVATE src)
+target_compile_features(ot_mhd PRIVATE cxx_std_17)
+target_compile_options(ot_mhd PRIVATE -Wall -Wextra -Wpedantic)
+
+if(OT_ENABLE_MPI)
+  set(OT_ADIOS_CANDIDATES
+    adios2::cxx_mpi
+    adios2::cxx11_mpi
+    adios2::cxx
+    adios2::cxx11
+    adios2::adios2
+  )
+else()
+  set(OT_ADIOS_CANDIDATES
+    adios2::cxx
+    adios2::cxx11
+    adios2::adios2
+    adios2::cxx_mpi
+    adios2::cxx11_mpi
+  )
+endif()
+
+set(OT_ADIOS_TARGET "")
+foreach(candidate IN LISTS OT_ADIOS_CANDIDATES)
+  if(TARGET ${candidate})
+    set(OT_ADIOS_TARGET ${candidate})
+    break()
+  endif()
+endforeach()
+
+if(OT_ADIOS_TARGET STREQUAL "")
+  message(FATAL_ERROR "No usable ADIOS2 C++ target exported by this installation")
+endif()
+
+target_link_libraries(ot_mhd PRIVATE ${OT_ADIOS_TARGET})
+
+if(OT_ENABLE_MPI)
+  target_compile_definitions(ot_mhd PRIVATE OT_USE_MPI=1)
+  target_link_libraries(ot_mhd PRIVATE MPI::MPI_CXX)
+endif()

--- a/examples/mhd_orszag_tang/README.md
+++ b/examples/mhd_orszag_tang/README.md
@@ -1,0 +1,284 @@
+# 2D Orszag-Tang MHD Example
+
+This directory contains the C++ solver sources for a 2D uniform-grid ideal-MHD
+Orszag-Tang vortex example.
+
+Included here:
+
+- `CMakeLists.txt`
+- `src/`
+- `scripts/run_ensembles.py`
+- `scripts/adios_stats.py`
+- `scripts/add_adios_files_to_campaign.py`
+- `scripts/render_adios_visualizations_to_campaign.py`
+- `ensembles/`
+
+Not yet moved into this repo:
+
+- rendering and analysis scripts
+- generated run output directories
+
+## Capabilities
+
+The solver supports:
+
+- multiple solver variants: `hll`, `rusanov`, `muscl_hll`, `muscl_rusanov`
+- optional MPI domain decomposition in `y`
+- ADIOS2 output
+- output cadence control by step and/or simulation time
+
+Each output step writes 2D fields such as:
+
+- `rho`
+- `pressure`
+- `vx`, `vy`, `vz`
+- `bx`, `by`, `bz`
+- `speed`
+- `current_z`
+
+Optional outputs:
+
+- `psi` via `--psi`
+- `mx`, `my`, `mz` via `--m`
+- `E` via `--E`
+
+Scalar diagnostics per step on rank 0 include:
+
+- `step`, `time`
+- `mass`
+- `kinetic_energy`, `magnetic_energy`, `internal_energy`, `total_energy`
+- `mean_pressure`
+- `max_speed`
+- `current_abs_max`, `current_rms`
+- `divb_abs_max`, `divb_l2`
+
+## Build
+
+Requirements:
+
+- CMake >= 3.18
+- C++17 compiler
+- ADIOS2 with C++ bindings
+- MPI (optional, enabled by default)
+
+From this directory:
+
+```bash
+cmake -S . -B build -DOT_ENABLE_MPI=ON
+cmake --build build -j
+```
+
+For a serial-only build:
+
+```bash
+cmake -S . -B build -DOT_ENABLE_MPI=OFF
+cmake --build build -j
+```
+
+## Run a single case
+
+Serial:
+
+```bash
+./build/ot_mhd \
+  --nx 512 --ny 512 \
+  --solver muscl_hll \
+  --tfinal 0.8 --cfl 0.3 \
+  --output-dir runs/ot_muscl \
+  --output-every-steps 20 \
+  --output-every-time 0.05
+```
+
+MPI:
+
+```bash
+mpirun -n 2 ./build/ot_mhd \
+  --nx 512 --ny 512 \
+  --solver muscl_hll \
+  --tfinal 0.8 --cfl 0.3 \
+  --output-dir runs/ot_muscl_mpi \
+  --output-every-steps 20 \
+  --output-every-time 0.05
+```
+
+Each run output directory contains:
+
+- `output.bp`
+- `input_parameters.txt`
+
+## Important controls
+
+- `--solver`: `rusanov`, `hll`, `muscl_hll`, `muscl_rusanov`
+- `--output-dir <path>`: writes `<path>/output.bp` and `<path>/input_parameters.txt`
+- `--prepend-var-names <str>`: prepends `<str>` to every ADIOS variable name
+- `--fixed-dt <float>`: force constant timestep
+- `--psi`: output the GLM cleaning field `psi`
+- `--m`: output momentum fields `mx`, `my`, `mz`
+- `--E`: output total energy density field `E`
+- `--output-every-steps N`: dump every `N` steps (`0` disables)
+- `--output-every-time dt`: dump every `dt` in simulation time (`0` disables)
+- `--save-initial` / `--no-save-initial`
+- `--glm-ch`, `--glm-damping` for divergence-cleaning behavior
+- `--rho-floor`, `--p-floor` for positivity
+
+Post-processing, analysis, and campaign-ingest helpers are planned to be moved
+into this example later.
+
+## Ensemble runner
+
+This example now includes a JSON-driven ensemble runner:
+
+```bash
+python3 scripts/run_ensembles.py --help
+```
+
+It expects a `--config` JSON file describing the ensemble.
+
+Available configs in `ensembles/`:
+
+- `resolution_sweep.json`
+- `simple.json`
+
+Examples:
+
+```bash
+python3 scripts/run_ensembles.py --binary ./build/ot_mhd --config ensembles/simple.json
+```
+
+Dry run:
+
+```bash
+python3 scripts/run_ensembles.py --binary ./build/ot_mhd --config ensembles/simple.json --dry-run
+```
+
+Run only selected members:
+
+```bash
+python3 scripts/run_ensembles.py --binary ./build/ot_mhd --config ensembles/simple.json --only muscl_hll hll_first_order
+```
+
+Override ranks for all selected runs:
+
+```bash
+python3 scripts/run_ensembles.py --binary ./build/ot_mhd --config ensembles/simple.json --ranks 8
+```
+
+Override the ensemble output root:
+
+```bash
+python3 scripts/run_ensembles.py --binary ./build/ot_mhd --config ensembles/simple.json --output-dir ./runs_custom
+```
+
+Resolution sweep example:
+
+```bash
+python3 scripts/run_ensembles.py --binary ./build/ot_mhd --config ensembles/resolution_sweep.json
+```
+
+The ensemble configs write run output under `runs/` relative to this example
+directory unless `--output-dir` is provided.
+
+## Campaign workflow
+
+Add all `output.bp` files from an ensemble run into a campaign:
+
+```bash
+source ~/venv/bin/activate
+python3 ./scripts/add_adios_files_to_campaign.py \
+  ./runs_resolution_sweep \
+  --archive mhd_resolution_sweep.aca
+```
+
+Generate per-step statistics for each ADIOS file and add both the primary data
+and sibling `*_stats.bp` datasets to the campaign:
+
+```bash
+python3 ./scripts/add_adios_files_to_campaign.py \
+  ./runs_resolution_sweep \
+  --archive mhd_resolution_sweep.aca \
+  --withStats
+```
+
+Existing stats datasets are reused by default. To regenerate them:
+
+```bash
+python3 ./scripts/add_adios_files_to_campaign.py \
+  ./runs_resolution_sweep \
+  --archive mhd_resolution_sweep.aca \
+  --withStats \
+  --forceStats
+```
+
+The stats script writes variables such as `rho_min`, `rho_max`, `rho_mean`,
+`rho_median`, `rho_std`, and `rho_var` into `output_stats.bp`.
+
+Generate derived variables and add both `output.bp` and `analysis.bp` to the
+campaign:
+
+```bash
+python3 ./scripts/add_adios_files_to_campaign.py \
+  ./runs_resolution_sweep \
+  --archive mhd_resolution_sweep.aca \
+  --withDerived
+```
+
+The derived analysis file contains `grad_rho_abs`, `grad_pressure_abs`, and
+`div_b` when the required source variables are present. Existing `analysis.bp`
+datasets are reused by default; add `--forceDerived` to regenerate them.
+
+To create a fresh campaign with primary data, derived data, and stats for both:
+
+```bash
+python3 ./scripts/add_adios_files_to_campaign.py \
+  ./runs_resolution_sweep \
+  --archive mhd_resolution_sweep.aca \
+  --withDerived \
+  --withStats \
+  --recreate \
+  --showInfo
+```
+
+Render one variable from every dataset into the campaign:
+
+```bash
+python3 ./scripts/render_adios_visualizations_to_campaign.py \
+  --archive mhd_resolution_sweep.aca \
+  --allDatasets \
+  --datasetPattern '*/output.bp' \
+  --variable rho \
+  --data_root ./runs_resolution_sweep
+```
+
+Render all variables from one dataset. Scalar variables are rendered as
+time-series plots over steps, while array variables are rendered as heatmaps:
+
+```bash
+python3 ./scripts/render_adios_visualizations_to_campaign.py \
+  --archive mhd_resolution_sweep.aca \
+  --dataset hll_128/output.bp \
+  --allVariables \
+  --data_root ./runs_resolution_sweep
+```
+
+Render velocity and magnetic streamlines for every primary ADIOS dataset:
+
+```bash
+python3 ./scripts/render_adios_visualizations_to_campaign.py \
+  --archive mhd_resolution_sweep.aca \
+  --datasetPattern '*/output.bp' \
+  --allVariables \
+  --visType streamlines \
+  --data_root ./runs_resolution_sweep \
+  --replace
+```
+
+Use `--variable velocity_streamlines` or `--variable magnetic_streamlines` to
+render only one streamline target.
+
+## TL;DR
+
+```bash
+python3 ./scripts/run_ensembles.py \
+  --binary ./build/ot_mhd \
+  --config ./ensembles/resolution_sweep.json
+```

--- a/examples/mhd_orszag_tang/ensembles/resolution_sweep.json
+++ b/examples/mhd_orszag_tang/ensembles/resolution_sweep.json
@@ -1,0 +1,54 @@
+{
+  "mpi_launcher": "mpirun -n {ranks}",
+  "output_dir": "../runs_resolution_sweep",
+  "default_ranks": 4,
+  "common_args": {
+    "tfinal": 1.0,
+    "cfl": 0.3,
+    "gamma": 1.6666666666666667,
+    "output_every_steps": 30,
+    "output_every_time": 0.05,
+    "log_every_steps": 30,
+    "glm_ch": 1.0,
+    "glm_damping": 0.1,
+    "save_initial": true
+  },
+  "runs": [
+    {
+      "name": "hll_128",
+      "solver": "hll",
+      "nx": 128,
+      "ny": 128
+    },
+    {
+      "name": "rusanov_128",
+      "solver": "rusanov",
+      "nx": 128,
+      "ny": 128
+    },
+    {
+      "name": "muscl_hll_128",
+      "solver": "muscl_hll",
+      "nx": 128,
+      "ny": 128
+    },
+    {
+      "name": "hll_256",
+      "solver": "hll",
+      "nx": 256,
+      "ny": 256
+    },
+    {
+      "name": "rusanov_256",
+      "solver": "rusanov",
+      "nx": 256,
+      "ny": 256
+    },
+    {
+      "name": "muscl_hll_256",
+      "solver": "muscl_hll",
+      "nx": 256,
+      "ny": 256
+    }
+  ]
+}

--- a/examples/mhd_orszag_tang/ensembles/simple.json
+++ b/examples/mhd_orszag_tang/ensembles/simple.json
@@ -1,0 +1,35 @@
+{
+  "mpi_launcher": "mpirun -n {ranks}",
+  "output_dir": "../runs",
+  "common_args": {
+    "nx": 128,
+    "ny": 128,
+    "tfinal": 1.0,
+    "cfl": 0.3,
+    "gamma": 1.6666666666666667,
+    "output_every_steps": 30,
+    "output_every_time": 0.05,
+    "log_every_steps": 30,
+    "glm_ch": 1.0,
+    "glm_damping": 0.1,
+    "save_initial": true
+  },
+  "runs": [
+    {
+      "name": "hll_first_order",
+      "solver": "hll",
+      "ranks": 4,
+      "prepend_var_names" : "hll_"
+    },
+    {
+      "name": "rusanov_first_order",
+      "solver": "rusanov",
+      "ranks": 4
+    },
+    {
+      "name": "muscl_hll",
+      "solver": "muscl_hll",
+      "ranks": 4
+    }      
+  ]
+}

--- a/examples/mhd_orszag_tang/scripts/add_adios_files_to_campaign.py
+++ b/examples/mhd_orszag_tang/scripts/add_adios_files_to_campaign.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""
+Create or update a campaign with only ADIOS/BP datasets.
+
+This is the first step in the intended notebook/script workflow:
+
+  1. Add simulation output BP files to the campaign.
+  2. Run analysis/rendering separately and add visualization image bytes with
+     the hpc-campaign visualization API.
+
+No rendered images or visualization metadata are added by this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import os
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+
+def _import_hpc_campaign():
+    """Prefer the local hpc-campaign checkout so new API branches are tested."""
+    script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parents[2]
+    candidate_checkouts = [
+        repo_root,
+        Path("~/proj/hpc_campaign/hpc-campaign").expanduser(),
+    ]
+
+    local_checkout = next((path for path in candidate_checkouts if path.exists()), None)
+    if local_checkout is not None:
+        local_checkout_str = str(local_checkout)
+        if local_checkout_str in sys.path:
+            sys.path.remove(local_checkout_str)
+        sys.path.insert(0, local_checkout_str)
+
+        existing = sys.modules.get("hpc_campaign")
+        existing_file = getattr(existing, "__file__", "") if existing is not None else ""
+        existing_path = getattr(existing, "__path__", []) if existing is not None else []
+        existing_locations = [str(entry) for entry in existing_path]
+        expected_package_dir = str(local_checkout / "hpc_campaign")
+        if (
+            existing is not None
+            and expected_package_dir not in existing_locations
+            and not str(existing_file).startswith(expected_package_dir)
+        ):
+            sys.modules.pop("hpc_campaign", None)
+            stale_submodules = [name for name in sys.modules if name.startswith("hpc_campaign.")]
+            for name in stale_submodules:
+                sys.modules.pop(name, None)
+
+    importlib.invalidate_caches()
+
+    try:
+        from hpc_campaign.info import format_info
+        from hpc_campaign.manager import Manager
+
+        return Manager, format_info
+    except ModuleNotFoundError as exc:
+        if exc.name == "adios2":
+            raise SystemExit(
+                "The hpc-campaign Python API requires the 'adios2' Python package in this environment."
+            ) from exc
+        if exc.name in {"hpc_campaign", "hpc_campaign.info", "hpc_campaign.manager"}:
+            raise SystemExit(
+                f"Could not import hpc-campaign from local checkout candidates: "
+                f"{', '.join(str(path) for path in candidate_checkouts)}."
+            ) from exc
+        raise
+
+
+@contextmanager
+def pushd(path: Path) -> Iterator[None]:
+    """Temporarily make dataset replica paths relative to the scan root."""
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def rel_posix(path: Path, root: Path) -> str:
+    """Return a stable campaign dataset name relative to the scan root."""
+    return path.relative_to(root).as_posix()
+
+
+def split_csv(values: list[str]) -> list[str]:
+    """Parse repeated comma-separated CLI values while preserving order."""
+    output: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        for item in value.split(","):
+            item = item.strip()
+            if item and item not in seen:
+                output.append(item)
+                seen.add(item)
+    return output
+
+
+def find_adios_datasets(out_root: Path, bp_names: list[str]) -> list[Path]:
+    """Find all requested BP dataset names under out_root."""
+    hits: set[Path] = set()
+    for bp_name in bp_names:
+        for path in out_root.rglob(bp_name):
+            if path.exists():
+                hits.add(path)
+    return sorted(hits)
+
+
+def is_stats_dataset(dataset_path: Path) -> bool:
+    """Return True for derived stats datasets named *_stats.<suffix>."""
+    return dataset_path.stem.endswith("_stats")
+
+
+def stats_output_path(input_path: Path) -> Path:
+    """Return the sibling stats path used by scripts/adios_stats.py."""
+    if input_path.suffix:
+        return input_path.with_name(f"{input_path.stem}_stats{input_path.suffix}")
+    return input_path.with_name(f"{input_path.name}_stats")
+
+
+def derived_output_path(input_path: Path, output_name: str) -> Path:
+    """Return the sibling derived-analysis BP path."""
+    return input_path.with_name(output_name)
+
+
+def _import_adios_stats():
+    """Import the local stats processor only when stats generation is requested."""
+    script_dir = Path(__file__).resolve().parent
+    script_dir_str = str(script_dir)
+    if script_dir_str not in sys.path:
+        sys.path.insert(0, script_dir_str)
+
+    from adios_stats import processFile  # pylint: disable=import-outside-toplevel
+
+    return processFile
+
+
+def _import_adios_derived_variables():
+    """Import the local derived-variable processor only when requested."""
+    script_dir = Path(__file__).resolve().parent
+    script_dir_str = str(script_dir)
+    if script_dir_str not in sys.path:
+        sys.path.insert(0, script_dir_str)
+
+    from adios_derived_variables import processFile  # pylint: disable=import-outside-toplevel
+
+    return processFile
+
+
+def add_derived_datasets(
+    datasets: list[Path],
+    derived_bp_name: str,
+    force_derived: bool,
+    dry_run: bool,
+) -> list[Path]:
+    """Generate/reuse sibling analysis BP files and return primary plus analysis datasets."""
+    expanded: list[Path] = []
+    process_file = None
+
+    for dataset_path in datasets:
+        expanded.append(dataset_path)
+
+        if is_stats_dataset(dataset_path):
+            print(f"[info] derived: skipping stats input {dataset_path}")
+            continue
+        if dataset_path.name == derived_bp_name:
+            print(f"[info] derived: skipping derived input {dataset_path}")
+            continue
+
+        output_path = derived_output_path(dataset_path, derived_bp_name)
+        should_generate = force_derived or not output_path.exists()
+
+        if should_generate:
+            if dry_run:
+                action = "regenerate" if output_path.exists() and force_derived else "generate"
+                print(f"[dry-run] derived: would {action} {output_path}")
+                expanded.append(output_path)
+            else:
+                if process_file is None:
+                    process_file = _import_adios_derived_variables()
+                action = "regenerating" if output_path.exists() and force_derived else "generating"
+                print(f"[info] derived: {action} {output_path}")
+                written_steps, written_vars = process_file(dataset_path, output_path)
+                if output_path.exists():
+                    expanded.append(output_path)
+                    print(f"[info] derived: wrote steps={written_steps} variables={len(written_vars)}")
+                else:
+                    print(f"[info] derived: no output written for {dataset_path}")
+        else:
+            print(f"[info] derived: reusing {output_path}")
+            expanded.append(output_path)
+
+    return sorted(dict.fromkeys(expanded))
+
+
+def add_stats_datasets(datasets: list[Path], force_stats: bool, dry_run: bool) -> list[Path]:
+    """Generate/reuse sibling stats BP files and return primary plus stats datasets."""
+    expanded: list[Path] = []
+    process_file = None
+
+    for dataset_path in datasets:
+        expanded.append(dataset_path)
+
+        if is_stats_dataset(dataset_path):
+            print(f"[info] stats: skipping stats input {dataset_path}")
+            continue
+
+        output_path = stats_output_path(dataset_path)
+        should_generate = force_stats or not output_path.exists()
+
+        if should_generate:
+            if dry_run:
+                action = "regenerate" if output_path.exists() and force_stats else "generate"
+                print(f"[dry-run] stats: would {action} {output_path}")
+            else:
+                if process_file is None:
+                    process_file = _import_adios_stats()
+                action = "regenerating" if output_path.exists() and force_stats else "generating"
+                print(f"[info] stats: {action} {output_path}")
+                process_file(dataset_path, output_path)
+        else:
+            print(f"[info] stats: reusing {output_path}")
+
+        expanded.append(output_path)
+
+    return sorted(dict.fromkeys(expanded))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Add only ADIOS/BP files to a campaign.")
+    parser.add_argument("outRoot", type=Path, help="Output root to scan.")
+    parser.add_argument("--archive", required=True, help="Campaign archive name/path.")
+    parser.add_argument("--campaign_store", default="", help="Campaign store path.")
+    parser.add_argument(
+        "--bpName",
+        action="append",
+        default=["output.bp"],
+        help=("BP dataset name to add. Can be repeated or comma-separated. Default: output.bp"),
+    )
+    parser.add_argument("--recreate", action="store_true", help="Truncate the existing campaign first.")
+    parser.add_argument("--dryRun", action="store_true", help="Print datasets that would be added.")
+    parser.add_argument("--showInfo", action="store_true", help="Print hpc-campaign info after writing.")
+    parser.add_argument(
+        "--withStats",
+        action="store_true",
+        help="Generate or reuse sibling *_stats BP files and add them to the campaign.",
+    )
+    parser.add_argument(
+        "--forceStats",
+        action="store_true",
+        help="Regenerate stats BP files when --withStats is set, replacing existing outputs.",
+    )
+    parser.add_argument(
+        "--withDerived",
+        action="store_true",
+        help="Generate or reuse sibling derived-analysis BP files and add them to the campaign.",
+    )
+    parser.add_argument(
+        "--forceDerived",
+        action="store_true",
+        help="Regenerate derived-analysis BP files when --withDerived is set, replacing existing outputs.",
+    )
+    parser.add_argument(
+        "--derivedBpName",
+        default="analysis.bp",
+        help="Sibling BP filename for derived variables. Default: analysis.bp",
+    )
+    return parser.parse_args()
+
+
+def print_plan(
+    archive: str,
+    out_root: Path,
+    bp_names: list[str],
+    datasets: list[Path],
+    with_stats: bool,
+    force_stats: bool,
+    with_derived: bool,
+    force_derived: bool,
+    derived_bp_name: str,
+) -> None:
+    print(f"[info] outRoot  : {out_root}")
+    print(f"[info] archive  : {archive}")
+    print(f"[info] bpName   : {bp_names}")
+    print(f"[info] datasets : {len(datasets)}")
+    print(f"[info] derived : {'enabled' if with_derived else 'disabled'}")
+    if with_derived:
+        print(f"[info] derived name : {derived_bp_name}")
+        print(f"[info] derived force: {force_derived}")
+    print(f"[info] stats    : {'enabled' if with_stats else 'disabled'}")
+    if with_stats:
+        print(f"[info] force    : {force_stats}")
+
+
+def add_datasets(manager: Any, datasets: list[Path], out_root: Path, dry_run: bool) -> int:
+    """Add ADIOS datasets with logical names matching their relative paths."""
+    added = 0
+    seen: set[str] = set()
+
+    with pushd(out_root):
+        for dataset_path in datasets:
+            rel_dataset = rel_posix(dataset_path, out_root)
+            if rel_dataset in seen:
+                continue
+            seen.add(rel_dataset)
+
+            print(f"[info] + dataset: {rel_dataset}")
+            if not dry_run:
+                manager.data(rel_dataset, name=rel_dataset)
+            added += 1
+
+    return added
+
+
+def main() -> int:
+    args = parse_args()
+
+    out_root = args.outRoot.expanduser().resolve()
+    if not out_root.exists():
+        raise SystemExit(f"Output root does not exist: {out_root}")
+
+    bp_names = split_csv(args.bpName)
+    if not bp_names:
+        raise SystemExit("At least one --bpName is required.")
+
+    datasets = find_adios_datasets(out_root, bp_names)
+    if not datasets:
+        raise SystemExit(f"No BP datasets named {bp_names} found under {out_root}")
+
+    print_plan(
+        args.archive,
+        out_root,
+        bp_names,
+        datasets,
+        args.withStats,
+        args.forceStats,
+        args.withDerived,
+        args.forceDerived,
+        args.derivedBpName,
+    )
+
+    if args.forceStats and not args.withStats:
+        raise SystemExit("--forceStats requires --withStats.")
+    if args.forceDerived and not args.withDerived:
+        raise SystemExit("--forceDerived requires --withDerived.")
+
+    if args.withDerived:
+        datasets = add_derived_datasets(datasets, args.derivedBpName, args.forceDerived, args.dryRun)
+        print(f"[info] datasets with derived: {len(datasets)}")
+
+    if args.withStats:
+        datasets = add_stats_datasets(datasets, args.forceStats, args.dryRun)
+        print(f"[info] datasets with stats: {len(datasets)}")
+
+    manager = None
+    format_info_fn = None
+    if not args.dryRun:
+        manager_class, format_info_fn = _import_hpc_campaign()
+        manager = manager_class(archive=args.archive, campaign_store=args.campaign_store)
+        manager.open(create=True, truncate=args.recreate)
+
+    try:
+        count = add_datasets(manager, datasets, out_root, args.dryRun)
+    finally:
+        if manager is not None:
+            manager.close()
+
+    print(f"[ok] done. datasets={count}")
+
+    if args.showInfo and not args.dryRun:
+        manager_class, format_info_fn = _import_hpc_campaign()
+        info_manager = manager_class(archive=args.archive, campaign_store=args.campaign_store)
+        print(format_info_fn(info_manager.info(list_replicas=False, list_files=False)))
+        info_manager.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/mhd_orszag_tang/scripts/adios_derived_variables.py
+++ b/examples/mhd_orszag_tang/scripts/adios_derived_variables.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Compute derived 2D variables from Orszag-Tang ADIOS2 output files."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+import numpy as np
+
+try:
+    from adios2.stream import Stream
+except ImportError as exc:
+    raise SystemExit("This script requires the Python package 'adios2'.") from exc
+
+
+DEFAULT_OUTPUT_NAME = "analysis.bp"
+DERIVED_DEPENDENCY_NAMES = {"rho", "pressure", "bx", "by"}
+
+
+def getOutputFilename(inputPath: Path, outputName: str = DEFAULT_OUTPUT_NAME) -> Path:
+    """Return the default sibling analysis BP path for an input dataset."""
+    return inputPath.with_name(outputName)
+
+
+def resetOutputPath(path: Path) -> None:
+    """Remove an existing output file/directory/symlink."""
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def to2d(field: np.ndarray) -> np.ndarray:
+    """Squeeze an ADIOS array to a 2D frame."""
+    data = np.asarray(field).squeeze()
+    while data.ndim > 2:
+        data = data[0]
+    if data.ndim != 2:
+        raise ValueError(f"Expected 2D data after squeeze, got ndim={data.ndim}")
+    return data
+
+
+def resolveVarName(available: set[str], logicalName: str) -> str | None:
+    """Resolve exact or prefix-style variable names such as hll_rho -> rho."""
+    if logicalName in available:
+        return logicalName
+
+    candidates = [name for name in available if name.endswith(logicalName)]
+    if not candidates:
+        return None
+
+    sep_candidates = [
+        name for name in candidates if len(name) > len(logicalName) and name[-len(logicalName) - 1] == "_"
+    ]
+    if sep_candidates:
+        candidates = sep_candidates
+
+    return min(candidates, key=len)
+
+
+def resolveVarNames(available: set[str], logicalNames: set[str]) -> dict[str, str]:
+    """Resolve a set of logical variable names against available ADIOS names."""
+    resolved: dict[str, str] = {}
+    for logicalName in sorted(logicalNames):
+        physicalName = resolveVarName(available, logicalName)
+        if physicalName is not None:
+            resolved[logicalName] = physicalName
+    return resolved
+
+
+def gradient2d(field: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return dy, dx gradients, preserving the old index-space behavior."""
+    return np.gradient(field)
+
+
+def computeDerivedFields(stepFields: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+    """Compute available derived fields from one timestep."""
+    derived: dict[str, np.ndarray] = {}
+
+    rho = stepFields.get("rho")
+    if rho is not None:
+        d_rho_dy, d_rho_dx = gradient2d(rho)
+        derived["grad_rho_abs"] = np.sqrt(d_rho_dx * d_rho_dx + d_rho_dy * d_rho_dy)
+
+    pressure = stepFields.get("pressure")
+    if pressure is not None:
+        d_p_dy, d_p_dx = gradient2d(pressure)
+        derived["grad_pressure_abs"] = np.sqrt(d_p_dx * d_p_dx + d_p_dy * d_p_dy)
+
+    bx = stepFields.get("bx")
+    by = stepFields.get("by")
+    if bx is not None and by is not None:
+        _d_bx_dy, d_bx_dx = gradient2d(bx)
+        d_by_dy, _d_by_dx = gradient2d(by)
+        derived["div_b"] = d_bx_dx + d_by_dy
+
+    return derived
+
+
+def processFile(inputPath: Path, outputPath: Path) -> tuple[int, list[str]]:
+    """Read one ADIOS dataset and write derived variables to outputPath."""
+    if outputPath.exists():
+        resetOutputPath(outputPath)
+
+    written_steps = 0
+    written_vars: set[str] = set()
+    skipped_steps = 0
+
+    with Stream(str(inputPath), "r") as source:
+        with Stream(str(outputPath), "w") as sink:
+            for step_index, _ in enumerate(source.steps()):
+                available = set((source.available_variables() or {}).keys())
+                dep_var_names = resolveVarNames(available, DERIVED_DEPENDENCY_NAMES)
+                step_fields: dict[str, np.ndarray] = {}
+
+                for dep_name in sorted(DERIVED_DEPENDENCY_NAMES):
+                    physical_name = dep_var_names.get(dep_name)
+                    if physical_name is None:
+                        continue
+                    try:
+                        arr = np.asarray(source.read(physical_name)).squeeze()
+                    except Exception as exc:  # noqa: BLE001
+                        print(
+                            f"[step {step_index}] skipping dependency '{physical_name}': "
+                            f"read failed ({type(exc).__name__}: {exc})"
+                        )
+                        continue
+                    if arr.ndim >= 2:
+                        try:
+                            step_fields[dep_name] = to2d(arr)
+                        except ValueError as exc:
+                            print(f"[step {step_index}] skipping dependency '{physical_name}': {exc}")
+
+                derived = computeDerivedFields(step_fields)
+                if not derived:
+                    skipped_steps += 1
+                    print(f"[step {step_index}] no derived fields available")
+                    continue
+
+                sink.begin_step()
+                for var_name, frame in sorted(derived.items()):
+                    arr2d = np.asarray(frame, dtype=np.float64)
+                    ny, nx = arr2d.shape
+                    sink.write(var_name, arr2d, [ny, nx], [0, 0], [ny, nx])
+                    written_vars.add(var_name)
+                sink.end_step()
+
+                written_steps += 1
+                print(f"[step {step_index}] written={len(derived)} vars={', '.join(sorted(derived))}")
+
+    if not written_vars and outputPath.exists():
+        resetOutputPath(outputPath)
+
+    if skipped_steps:
+        print(f"Skipped steps without derived fields: {skipped_steps}")
+
+    return written_steps, sorted(written_vars)
+
+
+def _format_vars(items: list[str], max_items: int = 10) -> str:
+    if len(items) <= max_items:
+        return ", ".join(items)
+    return f"{', '.join(items[:max_items])}, ... (+{len(items) - max_items} more)"
+
+
+def _discover_recursive_inputs(input_dir: Path, input_names: list[str]) -> list[Path]:
+    """Find files/dirs under input_dir that match any provided basename/pattern."""
+    found: dict[str, Path] = {}
+
+    for raw_name in input_names:
+        name = str(raw_name or "").strip()
+        if not name:
+            continue
+
+        matches = sorted(input_dir.rglob(name))
+        if not matches:
+            print(f"warning: no matches for '{name}' under {input_dir}")
+            continue
+
+        for match in matches:
+            if not (match.is_file() or match.is_dir()):
+                continue
+            resolved = match.resolve()
+            found[str(resolved)] = resolved
+
+    return sorted(found.values())
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compute derived Orszag-Tang variables from ADIOS2 files and write results to sibling analysis BP files."
+        )
+    )
+    parser.add_argument(
+        "--input",
+        nargs="+",
+        required=True,
+        help=(
+            "Single-file mode: one input file path. "
+            "Recursive mode (--input_dir): one or more filenames/patterns to match."
+        ),
+    )
+    parser.add_argument(
+        "--input_dir",
+        default="",
+        help="Optional root directory to search recursively for --input filenames.",
+    )
+    parser.add_argument(
+        "--output",
+        required=False,
+        default="",
+        help="Optional output file path (valid only in single-file mode).",
+    )
+    parser.add_argument(
+        "--outputName",
+        default=DEFAULT_OUTPUT_NAME,
+        help=f"Output BP name for recursive mode and single-file defaults. Default: {DEFAULT_OUTPUT_NAME}",
+    )
+    return parser.parse_args()
+
+
+def _process_single_input(inputPath: Path, outputPath: Path) -> None:
+    print(f"Input : {inputPath}")
+    print(f"Output: {outputPath}")
+
+    written_steps, written_vars = processFile(inputPath, outputPath)
+
+    print(f"Completed: steps={written_steps}, output_variables={len(written_vars)} ({_format_vars(written_vars)})")
+
+
+def _process_recursive_inputs(input_dir: Path, input_names: list[str], output_name: str) -> None:
+    matches = _discover_recursive_inputs(input_dir, input_names)
+    if not matches:
+        raise SystemExit(f"No matching input files found under: {input_dir}")
+
+    print(f"Input dir: {input_dir}")
+    print(f"Requested names: {', '.join(input_names)}")
+    print(f"Output name: {output_name}")
+    print(f"Matched files: {len(matches)}")
+
+    processed = 0
+    failed: list[str] = []
+    total_steps = 0
+    all_written_vars: set[str] = set()
+
+    for inputPath in matches:
+        outputPath = getOutputFilename(inputPath, output_name)
+        print("-" * 80)
+        print(f"Input : {inputPath}")
+        print(f"Output: {outputPath}")
+        try:
+            written_steps, written_vars = processFile(inputPath, outputPath)
+            total_steps += written_steps
+            all_written_vars.update(written_vars)
+            processed += 1
+            print(f"Completed file: steps={written_steps}, output_variables={len(written_vars)}")
+        except Exception as exc:  # noqa: BLE001
+            failed.append(str(inputPath))
+            print(f"ERROR: failed processing {inputPath}: {type(exc).__name__}: {exc}")
+
+    print("=" * 80)
+    print(
+        f"Summary: processed={processed}, failed={len(failed)}, "
+        f"total_steps={total_steps}, unique_output_variables={len(all_written_vars)}"
+    )
+    if failed:
+        print("Failed inputs:")
+        for path in failed:
+            print(f"  {path}")
+
+
+def main() -> None:
+    args = _parse_args()
+
+    input_dir_raw = str(args.input_dir or "").strip()
+    if input_dir_raw:
+        if args.output:
+            raise SystemExit("--output is only supported in single-file mode (without --input_dir).")
+
+        input_dir = Path(input_dir_raw).expanduser().resolve()
+        if not input_dir.is_dir():
+            raise SystemExit(f"input_dir is not a directory: {input_dir}")
+
+        _process_recursive_inputs(input_dir, [str(x) for x in args.input], str(args.outputName))
+        return
+
+    if len(args.input) != 1:
+        raise SystemExit("Single-file mode requires exactly one --input path.")
+
+    inputPath = Path(args.input[0]).expanduser().resolve()
+    if not inputPath.exists():
+        raise SystemExit(f"Input file not found: {inputPath}")
+
+    outputPath = (
+        Path(args.output).expanduser().resolve() if args.output else getOutputFilename(inputPath, str(args.outputName))
+    )
+    _process_single_input(inputPath, outputPath)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mhd_orszag_tang/scripts/adios_stats.py
+++ b/examples/mhd_orszag_tang/scripts/adios_stats.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Compute per-timestep statistics for numeric variables in ADIOS2 files."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+import numpy as np
+
+try:
+    from adios2.stream import Stream
+except ImportError as exc:
+    raise SystemExit("This script requires the Python package 'adios2'.") from exc
+
+
+STAT_NAMES = ("min", "max", "mean", "median", "std", "var")
+
+
+def getOutputFilename(inputPath: Path) -> Path:
+    """Return default output path by appending '_stats' before extension."""
+    if inputPath.suffix:
+        return inputPath.with_name(f"{inputPath.stem}_stats{inputPath.suffix}")
+    return inputPath.with_name(f"{inputPath.name}_stats")
+
+
+def resetOutputPath(path: Path) -> None:
+    """Remove an existing output file/directory/symlink."""
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def isNumericNdarray(arr: np.ndarray) -> bool:
+    """Return True only for integer/float ndarray dtypes."""
+    dtype = np.asarray(arr).dtype
+    return bool(np.issubdtype(dtype, np.integer) or np.issubdtype(dtype, np.floating))
+
+
+def computeStats(arr: np.ndarray) -> dict[str, float]:
+    """Compute min/max/mean/median/std/var over all elements using float64."""
+    flat64 = np.asarray(arr, dtype=np.float64).ravel()
+    return {
+        "min": float(np.min(flat64)),
+        "max": float(np.max(flat64)),
+        "mean": float(np.mean(flat64, dtype=np.float64)),
+        "median": float(np.median(flat64)),
+        "std": float(np.std(flat64, dtype=np.float64)),
+        "var": float(np.var(flat64, dtype=np.float64)),
+    }
+
+
+def _format_skip_list(items: list[str], max_items: int = 8) -> str:
+    if not items:
+        return "none"
+    if len(items) <= max_items:
+        return ", ".join(items)
+    shown = ", ".join(items[:max_items])
+    return f"{shown}, ... (+{len(items) - max_items} more)"
+
+
+def _discover_recursive_inputs(input_dir: Path, input_names: list[str]) -> list[Path]:
+    """Find files/dirs under input_dir that match any provided basename/pattern."""
+    found: dict[str, Path] = {}
+
+    for raw_name in input_names:
+        name = str(raw_name or "").strip()
+        if not name:
+            continue
+
+        matches = sorted(input_dir.rglob(name))
+        if not matches:
+            print(f"warning: no matches for '{name}' under {input_dir}")
+            continue
+
+        for match in matches:
+            if not (match.is_file() or match.is_dir()):
+                continue
+            resolved = match.resolve()
+            found[str(resolved)] = resolved
+
+    return sorted(found.values())
+
+
+def processFile(inputPath: Path, outputPath: Path) -> tuple[int, list[str]]:
+    """Read per-step variables, then write each stat variable once as shape (1, N)."""
+    if outputPath.exists():
+        resetOutputPath(outputPath)
+
+    written_steps = 0
+    written_vars: set[str] = set()
+    # out_name -> length-N list of per-step statistic values (NaN when missing)
+    time_series: dict[str, list[float]] = {}
+
+    with Stream(str(inputPath), "r") as source:
+        for step_index, _ in enumerate(source.steps()):
+            available = source.available_variables() or {}
+            variable_names = sorted(available.keys())
+
+            skipped_non_numeric: list[str] = []
+            skipped_read_failed: list[str] = []
+            skipped_empty: list[str] = []
+
+            step_stats: dict[str, float] = {}
+
+            for varName in variable_names:
+                try:
+                    arr = np.asarray(source.read(varName)).squeeze()
+                except Exception as exc:  # noqa: BLE001
+                    print(f"[step {step_index}] skipping '{varName}': read failed ({type(exc).__name__}: {exc})")
+                    skipped_read_failed.append(varName)
+                    continue
+
+                if arr.size == 0:
+                    print(f"[step {step_index}] skipping '{varName}': empty array")
+                    skipped_empty.append(varName)
+                    continue
+
+                if not isNumericNdarray(arr):
+                    print(f"[step {step_index}] skipping '{varName}': non-numeric dtype={arr.dtype}")
+                    skipped_non_numeric.append(varName)
+                    continue
+
+                stats = computeStats(arr)
+                for stat_name in STAT_NAMES:
+                    outName = f"{varName}_{stat_name}"
+                    step_stats[outName] = stats[stat_name]
+                    written_vars.add(outName)
+
+            # Ensure new variables are backfilled for earlier steps.
+            for outName in step_stats:
+                if outName not in time_series:
+                    time_series[outName] = [float("nan")] * written_steps
+
+            # Append this timestep for every known output variable.
+            for outName, series in time_series.items():
+                series.append(float(step_stats.get(outName, float("nan"))))
+
+            skipped_total = len(skipped_non_numeric) + len(skipped_read_failed) + len(skipped_empty)
+            print(f"[step {step_index}] vars={len(variable_names)} written={len(step_stats)} skipped={skipped_total}")
+            if skipped_non_numeric:
+                print(f"  non-numeric({len(skipped_non_numeric)}): {_format_skip_list(skipped_non_numeric)}")
+            if skipped_read_failed:
+                print(f"  read-failed({len(skipped_read_failed)}): {_format_skip_list(skipped_read_failed)}")
+            if skipped_empty:
+                print(f"  empty({len(skipped_empty)}): {_format_skip_list(skipped_empty)}")
+
+            written_steps += 1
+
+    # Write one output step: each variable is a 1xN array across all timesteps.
+    with Stream(str(outputPath), "w") as sink:
+        sink.begin_step()
+        for outName in sorted(time_series.keys()):
+            values = np.asarray(time_series[outName], dtype=np.float64).reshape(1, written_steps)
+            sink.write(outName, values, [1, written_steps], [0, 0], [1, written_steps])
+        sink.end_step()
+
+    return written_steps, sorted(written_vars)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compute per-timestep min/max/mean/median/std/var for each numeric variable "
+            "in ADIOS2 files and write results to sibling *_stats files."
+        )
+    )
+    parser.add_argument(
+        "--input",
+        nargs="+",
+        required=True,
+        help=(
+            "Single-file mode: one input file path. "
+            "Recursive mode (--input_dir): one or more filenames/patterns to match "
+            "(e.g., output.bp analysis.bp)."
+        ),
+    )
+    parser.add_argument(
+        "--input_dir",
+        default="",
+        help="Optional root directory to search recursively for --input filenames.",
+    )
+    parser.add_argument(
+        "--output",
+        required=False,
+        default="",
+        help="Optional output file path (valid only in single-file mode).",
+    )
+    return parser.parse_args()
+
+
+def _process_single_input(inputPath: Path, outputPath: Path) -> None:
+    print(f"Input : {inputPath}")
+    print(f"Output: {outputPath}")
+
+    written_steps, written_vars = processFile(inputPath, outputPath)
+
+    print(
+        f"Completed: steps={written_steps}, output_variables={len(written_vars)} "
+        f"({', '.join(written_vars[:10])}{'...' if len(written_vars) > 10 else ''})"
+    )
+
+
+def _process_recursive_inputs(input_dir: Path, input_names: list[str]) -> None:
+    matches = _discover_recursive_inputs(input_dir, input_names)
+    if not matches:
+        raise SystemExit(f"No matching input files found under: {input_dir}")
+
+    print(f"Input dir: {input_dir}")
+    print(f"Requested names: {', '.join(input_names)}")
+    print(f"Matched files: {len(matches)}")
+
+    processed = 0
+    failed: list[str] = []
+    total_steps = 0
+    all_written_vars: set[str] = set()
+
+    for inputPath in matches:
+        outputPath = getOutputFilename(inputPath)
+        print("-" * 80)
+        print(f"Input : {inputPath}")
+        print(f"Output: {outputPath}")
+        try:
+            written_steps, written_vars = processFile(inputPath, outputPath)
+            total_steps += written_steps
+            all_written_vars.update(written_vars)
+            processed += 1
+            print(f"Completed file: steps={written_steps}, output_variables={len(written_vars)}")
+        except Exception as exc:  # noqa: BLE001
+            failed.append(str(inputPath))
+            print(f"ERROR: failed processing {inputPath}: {type(exc).__name__}: {exc}")
+
+    print("=" * 80)
+    print(
+        f"Summary: processed={processed}, failed={len(failed)}, "
+        f"total_steps={total_steps}, unique_output_variables={len(all_written_vars)}"
+    )
+    if failed:
+        print("Failed inputs:")
+        for path in failed:
+            print(f"  {path}")
+
+
+def main() -> None:
+    args = _parse_args()
+
+    input_dir_raw = str(args.input_dir or "").strip()
+    if input_dir_raw:
+        if args.output:
+            raise SystemExit("--output is only supported in single-file mode (without --input_dir).")
+
+        input_dir = Path(input_dir_raw).expanduser().resolve()
+        if not input_dir.is_dir():
+            raise SystemExit(f"input_dir is not a directory: {input_dir}")
+
+        _process_recursive_inputs(input_dir, [str(x) for x in args.input])
+        return
+
+    if len(args.input) != 1:
+        raise SystemExit("Single-file mode requires exactly one --input path.")
+
+    inputPath = Path(args.input[0]).expanduser().resolve()
+    if not inputPath.exists():
+        raise SystemExit(f"Input file not found: {inputPath}")
+
+    outputPath = Path(args.output).expanduser().resolve() if args.output else getOutputFilename(inputPath)
+    _process_single_input(inputPath, outputPath)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mhd_orszag_tang/scripts/render_adios_visualizations_to_campaign.py
+++ b/examples/mhd_orszag_tang/scripts/render_adios_visualizations_to_campaign.py
@@ -1,0 +1,1296 @@
+#!/usr/bin/env python3
+"""
+Render single-variable ADIOS visualizations directly into a campaign.
+
+The script opens ADIOS/BP datasets already registered in a campaign, reads one
+or more variables, renders simple PNG images in memory, and stores those image
+bytes with Manager.visualization(). It can also write PNG files to disk for
+inspection, and optionally register those files as external image replicas.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import importlib
+import io
+import os
+import sys
+import tempfile
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+RANGE_ANALYSIS_PERCENTILE_LOW = 2.0
+RANGE_ANALYSIS_PERCENTILE_HIGH = 98.0
+RANGE_ANALYSIS_SIGNED_ABS_PERCENTILE = 98.0
+STREAMLINE_DENSITY = 1.2
+STREAMLINE_LINEWIDTH = 0.45
+STREAMLINE_ARROWSIZE = 0.6
+SIGNED_VARIABLE_NAMES = {
+    "mx",
+    "my",
+    "mz",
+    "vx",
+    "vy",
+    "vz",
+    "bx",
+    "by",
+    "bz",
+    "psi",
+    "current_z",
+    "jx",
+    "jy",
+    "jz",
+    "omega",
+    "u",
+    "v",
+    "w",
+    "div_b",
+}
+STREAMLINE_TARGETS = {
+    "velocity_streamlines": {
+        "components": ("vx", "vy"),
+        "background": "speed",
+        "fallback_background": "velocity_mag",
+    },
+    "magnetic_streamlines": {
+        "components": ("bx", "by"),
+        "background": "pressure",
+        "fallback_background": "bmag",
+    },
+}
+STREAMLINE_ALIASES = {
+    "velocity": "velocity_streamlines",
+    "velocity_streamline": "velocity_streamlines",
+    "velocity_streamlines": "velocity_streamlines",
+    "magnetic": "magnetic_streamlines",
+    "magnetic_streamline": "magnetic_streamlines",
+    "magnetic_streamlines": "magnetic_streamlines",
+}
+
+
+class MissingVariableError(RuntimeError):
+    """Raised when a requested ADIOS variable is not present in a dataset."""
+
+
+def _import_hpc_campaign():
+    """Prefer the local hpc-campaign checkout so new API branches are tested."""
+    script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parents[2]
+    candidate_checkouts = [
+        repo_root,
+        Path("~/proj/hpc_campaign/hpc-campaign").expanduser(),
+    ]
+
+    local_checkout = next((path for path in candidate_checkouts if path.exists()), None)
+    if local_checkout is not None:
+        local_checkout_str = str(local_checkout)
+        if local_checkout_str in sys.path:
+            sys.path.remove(local_checkout_str)
+        sys.path.insert(0, local_checkout_str)
+
+        existing = sys.modules.get("hpc_campaign")
+        existing_file = getattr(existing, "__file__", "") if existing is not None else ""
+        existing_path = getattr(existing, "__path__", []) if existing is not None else []
+        existing_locations = [str(entry) for entry in existing_path]
+        expected_package_dir = str(local_checkout / "hpc_campaign")
+        if (
+            existing is not None
+            and expected_package_dir not in existing_locations
+            and not str(existing_file).startswith(expected_package_dir)
+        ):
+            sys.modules.pop("hpc_campaign", None)
+            stale_submodules = [name for name in sys.modules if name.startswith("hpc_campaign.")]
+            for name in stale_submodules:
+                sys.modules.pop(name, None)
+
+    importlib.invalidate_caches()
+
+    try:
+        from hpc_campaign.info import format_info
+        from hpc_campaign.manager import Manager
+
+        return Manager, format_info
+    except ModuleNotFoundError as exc:
+        if exc.name == "adios2":
+            raise SystemExit(
+                "The hpc-campaign Python API requires the 'adios2' Python package in this environment."
+            ) from exc
+        if exc.name in {"hpc_campaign", "hpc_campaign.info", "hpc_campaign.manager"}:
+            raise SystemExit(
+                f"Could not import hpc-campaign from local checkout candidates: "
+                f"{', '.join(str(path) for path in candidate_checkouts)}."
+            ) from exc
+        raise
+
+
+def import_runtime_modules():
+    """Import ADIOS2 and matplotlib using a non-GUI backend."""
+    try:
+        import adios2
+    except ImportError as exc:
+        raise SystemExit("This script requires the Python package 'adios2'.") from exc
+
+    try:
+        cache_root = Path(tempfile.gettempdir()) / "hpc_campaign_visualization_cache"
+        cache_root.mkdir(parents=True, exist_ok=True)
+        os.environ.setdefault("MPLCONFIGDIR", str(cache_root / "matplotlib"))
+        os.environ.setdefault("XDG_CACHE_HOME", str(cache_root / "xdg"))
+
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        from matplotlib import colors as mcolors
+    except ImportError as exc:
+        raise SystemExit("This script requires matplotlib to render PNG images.") from exc
+
+    return adios2, plt, mcolors
+
+
+def split_csv(values: list[str] | None) -> list[str]:
+    """Parse repeated comma-separated CLI values while preserving order."""
+    if not values:
+        return []
+
+    output: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        for item in value.split(","):
+            item = item.strip()
+            if item and item not in seen:
+                output.append(item)
+                seen.add(item)
+    return output
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render single-variable ADIOS visualizations directly into an existing campaign."
+    )
+    parser.add_argument("--archive", required=True, help="Campaign archive name/path.")
+    parser.add_argument("--campaign_store", default="", help="Campaign store path.")
+    parser.add_argument(
+        "--dataset",
+        action="append",
+        default=None,
+        help="Exact campaign ADIOS dataset name. Can be repeated or comma-separated.",
+    )
+    parser.add_argument(
+        "--datasetPattern",
+        action="append",
+        default=None,
+        help="fnmatch pattern for campaign ADIOS dataset names, e.g. '*/output.bp'.",
+    )
+    parser.add_argument("--allDatasets", action="store_true", help="Render all ADIOS datasets in the campaign.")
+    variable_group = parser.add_mutually_exclusive_group()
+    variable_group.add_argument(
+        "--variable",
+        action="append",
+        help="ADIOS variable to render. Can be repeated or comma-separated.",
+    )
+    variable_group.add_argument(
+        "--allVariables",
+        action="store_true",
+        help="Render every ADIOS variable present in each selected dataset.",
+    )
+    parser.add_argument(
+        "--data_root",
+        type=Path,
+        default=None,
+        help="Root used to resolve relative BP replica paths stored in the campaign.",
+    )
+    parser.add_argument("--step", type=int, default=-1, help="Step to render. Negative means from the end.")
+    parser.add_argument("--allSteps", action="store_true", help="Render every ADIOS step instead of --step.")
+    parser.add_argument("--visType", default="heatmap", help="Visualization kind recorded in the campaign.")
+    parser.add_argument("--cmap", default="viridis", help="matplotlib colormap for 2D fields.")
+    parser.add_argument("--divergingCmap", default="RdBu_r", help="matplotlib colormap for signed 2D fields.")
+    parser.add_argument("--contourLevels", type=int, default=3, help="Number of contour levels for contour views.")
+    parser.add_argument(
+        "--contourLineWidth",
+        type=float,
+        default=0.6,
+        help="Contour line width for contour and heatmap_contour views.",
+    )
+    parser.add_argument("--dpi", type=int, default=150, help="Output image DPI.")
+    parser.add_argument("--figureWidth", type=float, default=6.0, help="Figure width in inches.")
+    parser.add_argument("--figureHeight", type=float, default=5.0, help="Figure height in inches.")
+    parser.add_argument(
+        "--name",
+        default=None,
+        help=(
+            "Short visualization name for one variable, expanded to "
+            "<dataset>/visualizations/<name>. If omitted, defaults to "
+            "<variable>_<visType>."
+        ),
+    )
+    parser.add_argument("--replace", action="store_true", help="Replace existing visualization sequences.")
+    parser.add_argument(
+        "--thumbnailStep",
+        type=int,
+        default=0,
+        help="Index within each rendered image list to use as the visualization thumbnail.",
+    )
+    parser.add_argument(
+        "--imageOutputDir",
+        type=Path,
+        default=None,
+        help=(
+            "Optional directory where rendered PNG files are written as "
+            "<dataset>/visualizations/<name>/image.<step>.png."
+        ),
+    )
+    parser.add_argument(
+        "--externalImages",
+        action="store_true",
+        help=(
+            "Register PNG files from --imageOutputDir as external image replicas "
+            "instead of storing in-memory PNG bytes in the campaign."
+        ),
+    )
+    parser.add_argument("--skipMissing", action="store_true", help="Skip datasets missing a requested variable.")
+    parser.add_argument("--dryRun", action="store_true", help="Print selected work without reading or writing images.")
+    parser.add_argument("--listDatasets", action="store_true", help="Print matching campaign datasets and exit.")
+    parser.add_argument("--showInfo", action="store_true", help="Print hpc-campaign info after writing.")
+    return parser.parse_args()
+
+
+def build_directory_map(info_data) -> dict[int, str]:
+    """Build a lookup from hpc-campaign directory id to directory path."""
+    directories: dict[int, str] = {}
+    for host in info_data.hosts:
+        for directory in host.directories:
+            directories[directory.id] = directory.name
+    return directories
+
+
+def live_adios_datasets(info_data) -> list[Any]:
+    """Return live ADIOS datasets sorted by campaign dataset name."""
+    datasets = []
+    for dataset in info_data.datasets.values():
+        if dataset.del_time == 0 and dataset.file_format == "ADIOS":
+            datasets.append(dataset)
+    return sorted(datasets, key=lambda item: item.name)
+
+
+def select_datasets(
+    info_data,
+    exact_names: list[str],
+    patterns: list[str],
+    all_datasets: bool,
+) -> list[Any]:
+    """Select campaign ADIOS datasets by exact name, pattern, or all-datasets mode."""
+    available = live_adios_datasets(info_data)
+    if all_datasets:
+        return available
+
+    selected: list[Any] = []
+    seen: set[str] = set()
+    by_name = {dataset.name: dataset for dataset in available}
+
+    for name in exact_names:
+        dataset = by_name.get(name)
+        if dataset is None:
+            raise SystemExit(f"ADIOS dataset not found in campaign: {name}")
+        if dataset.name not in seen:
+            selected.append(dataset)
+            seen.add(dataset.name)
+
+    for pattern in patterns:
+        for dataset in available:
+            if fnmatch.fnmatch(dataset.name, pattern) and dataset.name not in seen:
+                selected.append(dataset)
+                seen.add(dataset.name)
+
+    if not selected:
+        raise SystemExit("Select at least one dataset with --dataset, --datasetPattern, or --allDatasets.")
+
+    return selected
+
+
+def list_dataset_names(datasets: list[Any]) -> None:
+    for dataset in datasets:
+        print(dataset.name)
+
+
+def candidate_replica_paths(dataset, data_root: Path | None, directory_map: dict[int, str]) -> list[Path]:
+    """
+    Generate possible local filesystem paths for a dataset replica.
+
+    For campaigns created from a scan root, data_root / replica.name is usually
+    the path that resolves.
+    """
+    candidates: list[Path] = []
+    for replica in dataset.replicas.values():
+        if replica.del_time != 0 or replica.flags.deleted or replica.flags.embedded:
+            continue
+
+        replica_path = Path(replica.name)
+        if replica_path.is_absolute():
+            candidates.append(replica_path)
+        if data_root is not None:
+            candidates.append(data_root / replica.name)
+
+        directory_name = directory_map.get(replica.dir_id)
+        if directory_name:
+            directory_path = Path(directory_name)
+            if directory_path.is_absolute():
+                candidates.append(directory_path / replica.name)
+
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = str(candidate)
+        if key not in seen:
+            deduped.append(candidate)
+            seen.add(key)
+    return deduped
+
+
+def resolve_dataset_path(dataset, data_root: Path | None, directory_map: dict[int, str]) -> Path:
+    """Return the first existing local path for a campaign ADIOS dataset."""
+    candidates = candidate_replica_paths(dataset, data_root, directory_map)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    candidate_text = "\n".join(f"  {path}" for path in candidates) or "  <none>"
+    raise SystemExit(
+        f"Could not resolve a local path for dataset {dataset.name!r}. Tried:\n"
+        f"{candidate_text}\n"
+        "Pass --data_root pointing at the root used when the campaign was created."
+    )
+
+
+def normalize_step_selection(step: int, nsteps: int) -> int:
+    """Translate a possibly negative step index into a valid ADIOS step."""
+    resolved = step if step >= 0 else nsteps + step
+    if resolved < 0 or resolved >= nsteps:
+        raise SystemExit(f"Invalid step {step}; available range is [0, {nsteps - 1}]")
+    return resolved
+
+
+def read_stream_arrays(
+    adios2, bp_path: Path, variable: str, step: int, all_steps: bool
+) -> tuple[list[int], list[np.ndarray]]:
+    """
+    Read ADIOS arrays using adios2.Stream, matching the existing MHD renderer.
+
+    For a single non-negative step, the stream stops after that frame. For a
+    negative step, only the needed trailing frames are kept in memory.
+    """
+    steps: list[int] = []
+    arrays: list[np.ndarray] = []
+    trailing: deque[tuple[int, np.ndarray]] = deque(maxlen=max(1, abs(step)))
+    saw_any_step = False
+
+    with adios2.Stream(str(bp_path), "r") as stream:
+        for frame_index, _ in enumerate(stream.steps()):
+            saw_any_step = True
+            available = set((stream.available_variables() or {}).keys())
+            if variable not in available:
+                preview = ", ".join(sorted(available)[:20])
+                raise MissingVariableError(
+                    f"Variable {variable!r} not found in {bp_path} at step {frame_index}. "
+                    f"Available variables include: {preview}"
+                )
+
+            if all_steps:
+                steps.append(frame_index)
+                arrays.append(np.asarray(stream.read(variable)).squeeze())
+                continue
+
+            if step >= 0:
+                if frame_index == step:
+                    steps.append(frame_index)
+                    arrays.append(np.asarray(stream.read(variable)).squeeze())
+                    break
+                continue
+
+            trailing.append((frame_index, np.asarray(stream.read(variable)).squeeze()))
+
+    if not saw_any_step:
+        raise SystemExit(f"No steps found in ADIOS file: {bp_path}")
+
+    if not all_steps and step < 0:
+        if len(trailing) < abs(step):
+            raise SystemExit(f"Invalid step {step}; available steps={len(trailing)} or fewer were found")
+        selected_step, selected_array = trailing[0]
+        steps = [selected_step]
+        arrays = [selected_array]
+
+    if not arrays:
+        raise SystemExit(f"Step {step} was not found in ADIOS file: {bp_path}")
+
+    return steps, arrays
+
+
+def reader_num_steps(reader) -> int:
+    """Return the number of ADIOS steps for FileReader-like APIs."""
+    try:
+        return int(reader.steps())
+    except AttributeError:
+        return int(reader.num_steps())
+
+
+def read_variable_step(reader, variable: str, step: int) -> np.ndarray:
+    """Read one variable at one step with ADIOS2 signature compatibility."""
+    try:
+        data = reader.read(variable, step_selection=[step, 1])
+    except TypeError:
+        data = reader.read(variable, start=[], count=[], step_selection=[step, 1])
+    return np.asarray(data).squeeze()
+
+
+def read_filereader_arrays(
+    adios2,
+    bp_path: Path,
+    variable: str,
+    step: int,
+    all_steps: bool,
+) -> tuple[list[int], list[np.ndarray]]:
+    """Fallback reader for ADIOS2 builds without Stream."""
+    with adios2.FileReader(str(bp_path)) as reader:
+        available = set((reader.available_variables() or {}).keys())
+        if variable not in available:
+            preview = ", ".join(sorted(available)[:20])
+            raise MissingVariableError(
+                f"Variable {variable!r} not found in {bp_path}. Available variables include: {preview}"
+            )
+
+        nsteps = reader_num_steps(reader)
+        if nsteps <= 0:
+            raise SystemExit(f"No steps found in ADIOS file: {bp_path}")
+
+        steps = list(range(nsteps)) if all_steps else [normalize_step_selection(step, nsteps)]
+        arrays = [read_variable_step(reader, variable, step_index) for step_index in steps]
+    return steps, arrays
+
+
+def read_variable_arrays(
+    bp_path: Path, variable: str, step: int, all_steps: bool
+) -> tuple[list[int], list[np.ndarray]]:
+    """Read one ADIOS variable from one dataset."""
+    adios2, _, _ = import_runtime_modules()
+    if hasattr(adios2, "Stream"):
+        return read_stream_arrays(adios2, bp_path, variable, step, all_steps)
+    if hasattr(adios2, "FileReader"):
+        return read_filereader_arrays(adios2, bp_path, variable, step, all_steps)
+    raise SystemExit("This ADIOS2 Python module exposes neither Stream nor FileReader.")
+
+
+def discover_stream_variables(adios2, bp_path: Path) -> list[str]:
+    """Return variable names from the first ADIOS step using Stream."""
+    with adios2.Stream(str(bp_path), "r") as stream:
+        for _, _step in enumerate(stream.steps()):
+            return sorted((stream.available_variables() or {}).keys())
+    raise SystemExit(f"No steps found in ADIOS file: {bp_path}")
+
+
+def discover_filereader_variables(adios2, bp_path: Path) -> list[str]:
+    """Return variable names using the FileReader metadata path."""
+    with adios2.FileReader(str(bp_path)) as reader:
+        if reader_num_steps(reader) <= 0:
+            raise SystemExit(f"No steps found in ADIOS file: {bp_path}")
+        return sorted((reader.available_variables() or {}).keys())
+
+
+def discover_variables(bp_path: Path) -> list[str]:
+    """Discover available ADIOS variables for one dataset."""
+    adios2, _, _ = import_runtime_modules()
+    if hasattr(adios2, "Stream"):
+        return discover_stream_variables(adios2, bp_path)
+    if hasattr(adios2, "FileReader"):
+        return discover_filereader_variables(adios2, bp_path)
+    raise SystemExit("This ADIOS2 Python module exposes neither Stream nor FileReader.")
+
+
+def normalize_vis_type(vis_type: str) -> str:
+    normalized = str(vis_type or "heatmap").strip().lower().replace("-", "_")
+    if normalized == "streamline":
+        return "streamlines"
+    return normalized or "heatmap"
+
+
+def normalize_streamline_target(variable: str) -> str | None:
+    """Map user-facing streamline variable names to internal target tokens."""
+    token = str(variable or "").strip().lower().replace("-", "_")
+    return STREAMLINE_ALIASES.get(token)
+
+
+def canonical_var_name(name: str) -> str:
+    for logical_name in sorted(SIGNED_VARIABLE_NAMES, key=len, reverse=True):
+        if name == logical_name or name.endswith(logical_name):
+            return logical_name
+    return name
+
+
+def is_signed_variable(name: str) -> bool:
+    return canonical_var_name(name) in SIGNED_VARIABLE_NAMES
+
+
+def to_2d(field: np.ndarray) -> np.ndarray:
+    data = np.asarray(field).squeeze()
+    while data.ndim > 2:
+        data = data[0]
+    if data.ndim != 2:
+        raise ValueError(f"Expected 2D data after squeeze, got ndim={data.ndim}")
+    return data
+
+
+def resolve_var_name(available: set[str], logical_name: str) -> str | None:
+    """Resolve exact or prefix-style ADIOS names such as hll_vx -> vx."""
+    if logical_name in available:
+        return logical_name
+
+    candidates = [name for name in available if name.endswith(logical_name)]
+    if not candidates:
+        return None
+
+    sep_candidates = [
+        name for name in candidates if len(name) > len(logical_name) and name[-len(logical_name) - 1] == "_"
+    ]
+    if sep_candidates:
+        candidates = sep_candidates
+
+    return min(candidates, key=len)
+
+
+def available_streamline_targets(variable_names: list[str]) -> list[str]:
+    """Return streamline targets whose vector components are present."""
+    available = set(variable_names)
+    targets: list[str] = []
+    for target_name, spec in STREAMLINE_TARGETS.items():
+        u_name, v_name = spec["components"]
+        if resolve_var_name(available, u_name) is not None and resolve_var_name(available, v_name) is not None:
+            targets.append(target_name)
+    return targets
+
+
+def sanitize_limits(vmin: float, vmax: float) -> tuple[float, float]:
+    if not np.isfinite(vmin) or not np.isfinite(vmax):
+        return (0.0, 1.0)
+    if vmin == vmax:
+        delta = 1.0 if vmin == 0.0 else abs(vmin) * 1.0e-6
+        return (vmin - delta, vmax + delta)
+    return (vmin, vmax)
+
+
+def downsample_finite_values(values: np.ndarray, max_points: int = 200000) -> np.ndarray:
+    flat = np.asarray(values, dtype=float).reshape(-1)
+    finite = flat[np.isfinite(flat)]
+    if finite.size <= max_points:
+        return finite
+    step = max(1, int(np.ceil(finite.size / float(max_points))))
+    return finite[::step][:max_points]
+
+
+def display_limits_for_arrays(variable_name: str, arrays: list[np.ndarray]) -> tuple[float, float]:
+    samples: list[np.ndarray] = []
+    fallback_min = np.inf
+    fallback_max = -np.inf
+
+    for array in arrays:
+        try:
+            frame = to_2d(array)
+        except ValueError:
+            continue
+        finite = downsample_finite_values(frame)
+        if finite.size == 0:
+            continue
+        samples.append(finite)
+        fallback_min = min(fallback_min, float(np.nanmin(finite)))
+        fallback_max = max(fallback_max, float(np.nanmax(finite)))
+
+    fallback_min, fallback_max = sanitize_limits(float(fallback_min), float(fallback_max))
+    if not samples:
+        return (fallback_min, fallback_max)
+
+    merged = downsample_finite_values(np.concatenate(samples))
+    if merged.size < 2:
+        return (fallback_min, fallback_max)
+
+    if is_signed_variable(variable_name):
+        sample_min = float(np.nanmin(merged))
+        sample_max = float(np.nanmax(merged))
+        if sample_min < 0.0 < sample_max:
+            abs_cap = float(np.nanpercentile(np.abs(merged), RANGE_ANALYSIS_SIGNED_ABS_PERCENTILE))
+            if np.isfinite(abs_cap) and abs_cap > 0.0:
+                return sanitize_limits(-abs_cap, abs_cap)
+
+    low = float(np.nanpercentile(merged, RANGE_ANALYSIS_PERCENTILE_LOW))
+    high = float(np.nanpercentile(merged, RANGE_ANALYSIS_PERCENTILE_HIGH))
+    return sanitize_limits(low, high)
+
+
+def contour_levels_from_limits(vmin: float, vmax: float, level_count: int) -> np.ndarray | None:
+    if level_count < 2 or not np.isfinite(vmin) or not np.isfinite(vmax) or vmin >= vmax:
+        return None
+
+    levels = np.linspace(float(vmin), float(vmax), int(level_count), dtype=float)
+    levels = np.unique(levels)
+    if levels.size < 2:
+        return None
+    return levels
+
+
+def choose_cmap(variable_name: str, sequential_cmap: str, diverging_cmap: str) -> str:
+    return diverging_cmap if is_signed_variable(variable_name) else sequential_cmap
+
+
+def choose_norm(variable_name: str, vmin: float, vmax: float, mcolors):
+    if is_signed_variable(variable_name) and vmin < 0.0 < vmax:
+        return mcolors.TwoSlopeNorm(vmin=vmin, vcenter=0.0, vmax=vmax)
+    return mcolors.Normalize(vmin=vmin, vmax=vmax)
+
+
+def render_array_to_png_bytes(
+    array: np.ndarray,
+    variable_name: str,
+    title: str,
+    vis_type: str,
+    sequential_cmap: str,
+    diverging_cmap: str,
+    contour_level_count: int,
+    contour_line_width: float,
+    display_limits: tuple[float, float] | None,
+    dpi: int,
+    figure_size: tuple[float, float],
+    plt,
+    mcolors,
+) -> bytes:
+    """Render scalar, 1D, heatmap, contour, or heatmap_contour PNG bytes."""
+    arr = np.asarray(array).squeeze()
+    fig, ax = plt.subplots(figsize=figure_size, constrained_layout=True)
+
+    if arr.ndim == 0:
+        ax.text(0.5, 0.5, f"{float(arr):.6g}", ha="center", va="center", fontsize=18)
+        ax.set_axis_off()
+    elif arr.ndim == 1:
+        ax.plot(np.arange(arr.shape[0]), arr)
+        ax.set_xlabel("Index")
+        ax.set_ylabel("Value")
+    else:
+        frame = to_2d(arr)
+        if display_limits is None:
+            vmin, vmax = sanitize_limits(float(np.nanmin(frame)), float(np.nanmax(frame)))
+        else:
+            vmin, vmax = display_limits
+
+        cmap = choose_cmap(variable_name, sequential_cmap, diverging_cmap)
+        norm = choose_norm(variable_name, vmin, vmax, mcolors)
+        levels = contour_levels_from_limits(vmin, vmax, contour_level_count)
+        render_kind = normalize_vis_type(vis_type)
+        uses_diverging = is_signed_variable(variable_name) and vmin < 0.0 < vmax
+
+        if render_kind == "contour":
+            if levels is not None:
+                ax.contour(frame, levels=levels, origin="lower", linewidths=contour_line_width, colors="black")
+            else:
+                ax.text(0.5, 0.5, "No contour levels", ha="center", va="center", transform=ax.transAxes)
+        else:
+            image = ax.imshow(frame, origin="lower", cmap=cmap, norm=norm, aspect="auto")
+            if render_kind == "heatmap_contour" and levels is not None:
+                overlay_color = "black" if uses_diverging else "white"
+                ax.contour(
+                    frame,
+                    levels=levels,
+                    origin="lower",
+                    linewidths=contour_line_width,
+                    colors=overlay_color,
+                )
+            fig.colorbar(image, ax=ax, fraction=0.046, pad=0.04)
+
+        ax.set_xticks([])
+        ax.set_yticks([])
+
+    ax.set_title(title)
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="png", dpi=dpi)
+    plt.close(fig)
+    return buffer.getvalue()
+
+
+def render_scalar_timeseries_to_png_bytes(
+    steps: list[int],
+    arrays: list[np.ndarray],
+    title: str,
+    dpi: int,
+    figure_size: tuple[float, float],
+    plt,
+) -> bytes:
+    """Render one scalar variable across all steps as a time-series PNG."""
+    values = [float(np.asarray(array).squeeze()) for array in arrays]
+    fig, ax = plt.subplots(figsize=figure_size, constrained_layout=True)
+    ax.plot(steps, values, marker="o")
+    ax.set_xlabel("Step")
+    ax.set_ylabel("Value")
+    ax.set_title(title)
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="png", dpi=dpi)
+    plt.close(fig)
+    return buffer.getvalue()
+
+
+def read_streamline_arrays(
+    bp_path: Path,
+    target: str,
+    step: int,
+    all_steps: bool,
+) -> tuple[list[int], list[np.ndarray], list[np.ndarray], list[np.ndarray], str]:
+    """Read vector components plus background arrays for one streamline target."""
+    target_name = normalize_streamline_target(target)
+    if target_name is None:
+        choices = ", ".join(sorted(STREAMLINE_TARGETS))
+        raise MissingVariableError(f"Unknown streamline target {target!r}. Use one of: {choices}")
+
+    available = set(discover_variables(bp_path))
+    spec = STREAMLINE_TARGETS[target_name]
+    u_logical, v_logical = spec["components"]
+    u_var = resolve_var_name(available, str(u_logical))
+    v_var = resolve_var_name(available, str(v_logical))
+    if u_var is None or v_var is None:
+        preview = ", ".join(sorted(available)[:20])
+        raise MissingVariableError(
+            f"Streamline target {target_name!r} requires variables {u_logical!r} and {v_logical!r} "
+            f"in {bp_path}. Available variables include: {preview}"
+        )
+
+    steps, u_arrays = read_variable_arrays(bp_path, u_var, step, all_steps)
+    v_steps, v_arrays = read_variable_arrays(bp_path, v_var, step, all_steps)
+    if v_steps != steps:
+        raise SystemExit(f"Step mismatch while reading {u_var!r} and {v_var!r} from {bp_path}")
+
+    background_name = str(spec["background"])
+    background_var = resolve_var_name(available, background_name)
+    if background_var is not None:
+        background_steps, background_arrays = read_variable_arrays(bp_path, background_var, step, all_steps)
+        if background_steps != steps:
+            raise SystemExit(f"Step mismatch while reading streamline background {background_var!r} from {bp_path}")
+    else:
+        background_name = str(spec["fallback_background"])
+        background_arrays = []
+        for u_array, v_array in zip(u_arrays, v_arrays, strict=True):
+            u = to_2d(u_array)
+            v = to_2d(v_array)
+            if u.shape != v.shape:
+                raise SystemExit(f"Shape mismatch while building {background_name}: {u.shape} vs {v.shape}")
+            background_arrays.append(np.sqrt(u * u + v * v))
+
+    return steps, u_arrays, v_arrays, background_arrays, background_name
+
+
+def render_streamline_to_png_bytes(
+    background: np.ndarray,
+    background_name: str,
+    u: np.ndarray,
+    v: np.ndarray,
+    title: str,
+    sequential_cmap: str,
+    diverging_cmap: str,
+    display_limits: tuple[float, float],
+    dpi: int,
+    figure_size: tuple[float, float],
+    plt,
+    mcolors,
+) -> bytes:
+    """Render one streamline frame over a scalar background."""
+    background2d = to_2d(background)
+    u2d = to_2d(u)
+    v2d = to_2d(v)
+    if u2d.shape != v2d.shape or u2d.shape != background2d.shape:
+        raise SystemExit(f"Streamline shape mismatch: background={background2d.shape}, u={u2d.shape}, v={v2d.shape}")
+
+    vmin, vmax = display_limits
+    cmap = choose_cmap(background_name, sequential_cmap, diverging_cmap)
+    norm = choose_norm(background_name, vmin, vmax, mcolors)
+
+    u_plot = np.nan_to_num(u2d, nan=0.0, posinf=0.0, neginf=0.0)
+    v_plot = np.nan_to_num(v2d, nan=0.0, posinf=0.0, neginf=0.0)
+    mag = np.sqrt(u_plot * u_plot + v_plot * v_plot)
+    finite_mag = mag[np.isfinite(mag)]
+    width: float | np.ndarray = STREAMLINE_LINEWIDTH
+    if finite_mag.size >= 2:
+        ref = float(np.nanpercentile(finite_mag, 95.0))
+        if np.isfinite(ref) and ref > 0.0:
+            width = STREAMLINE_LINEWIDTH * (0.5 + 0.5 * np.clip(mag / ref, 0.0, 1.0))
+
+    ny, nx = u_plot.shape
+    x = np.arange(nx, dtype=float)
+    y = np.arange(ny, dtype=float)
+
+    fig, ax = plt.subplots(figsize=figure_size, constrained_layout=True)
+    image = ax.imshow(background2d, origin="lower", cmap=cmap, norm=norm, aspect="auto")
+    try:
+        ax.streamplot(
+            x,
+            y,
+            u_plot,
+            v_plot,
+            density=STREAMLINE_DENSITY,
+            linewidth=width,
+            color="white",
+            arrowsize=STREAMLINE_ARROWSIZE,
+            minlength=0.08,
+            maxlength=4.0,
+            integration_direction="both",
+            broken_streamlines=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[warn] streamplot failed for {title}: {type(exc).__name__}: {exc}")
+    ax.set_xticks([])
+    ax.set_yticks([])
+    ax.set_title(title)
+    fig.colorbar(image, ax=ax, fraction=0.046, pad=0.04)
+
+    buffer = io.BytesIO()
+    fig.savefig(buffer, format="png", dpi=dpi)
+    plt.close(fig)
+    return buffer.getvalue()
+
+
+def render_streamline_images(
+    dataset_name: str,
+    variable: str,
+    bp_path: Path,
+    step: int,
+    all_steps: bool,
+    cmap: str,
+    diverging_cmap: str,
+    dpi: int,
+    figure_size: tuple[float, float],
+) -> tuple[list[int], list[bytes], str]:
+    """Read vector components and render streamline PNG bytes."""
+    _, plt, mcolors = import_runtime_modules()
+    print(f"[info] reading streamline target: {bp_path}")
+    steps, u_arrays, v_arrays, background_arrays, background_name = read_streamline_arrays(
+        bp_path, variable, step, all_steps
+    )
+    display_limits = display_limits_for_arrays(background_name, background_arrays)
+
+    images: list[bytes] = []
+    for step_index, u_array, v_array, background in zip(steps, u_arrays, v_arrays, background_arrays, strict=True):
+        title = f"{dataset_name}:{variable} step={step_index}"
+        images.append(
+            render_streamline_to_png_bytes(
+                background=background,
+                background_name=background_name,
+                u=u_array,
+                v=v_array,
+                title=title,
+                sequential_cmap=cmap,
+                diverging_cmap=diverging_cmap,
+                display_limits=display_limits,
+                dpi=dpi,
+                figure_size=figure_size,
+                plt=plt,
+                mcolors=mcolors,
+            )
+        )
+    return steps, images, "streamlines"
+
+
+def render_images(
+    dataset_name: str,
+    variable: str,
+    bp_path: Path,
+    step: int,
+    all_steps: bool,
+    vis_type: str,
+    cmap: str,
+    diverging_cmap: str,
+    contour_level_count: int,
+    contour_line_width: float,
+    dpi: int,
+    figure_size: tuple[float, float],
+) -> tuple[list[int], list[bytes], str]:
+    """Read one variable and render each selected step to PNG bytes."""
+    resolved_vis_type = normalize_vis_type(vis_type)
+    if resolved_vis_type == "streamlines":
+        return render_streamline_images(
+            dataset_name=dataset_name,
+            variable=variable,
+            bp_path=bp_path,
+            step=step,
+            all_steps=all_steps,
+            cmap=cmap,
+            diverging_cmap=diverging_cmap,
+            dpi=dpi,
+            figure_size=figure_size,
+        )
+
+    _, plt, mcolors = import_runtime_modules()
+    print(f"[info] reading: {bp_path}")
+    steps, arrays = read_variable_arrays(bp_path, variable, step, all_steps)
+
+    first_array = np.asarray(arrays[0]).squeeze()
+    if first_array.ndim == 0:
+        if not all_steps or len(steps) == 1:
+            steps, arrays = read_variable_arrays(bp_path, variable, step=0, all_steps=True)
+        title = f"{dataset_name}:{variable} over steps"
+        image = render_scalar_timeseries_to_png_bytes(steps, arrays, title, dpi, figure_size, plt)
+        return steps, [image], "timeseries"
+
+    display_limits = display_limits_for_arrays(variable, arrays) if first_array.ndim >= 2 else None
+
+    images: list[bytes] = []
+    for step_index, array in zip(steps, arrays, strict=True):
+        title = f"{dataset_name}:{variable} step={step_index}"
+        images.append(
+            render_array_to_png_bytes(
+                array=array,
+                variable_name=variable,
+                title=title,
+                vis_type=resolved_vis_type,
+                sequential_cmap=cmap,
+                diverging_cmap=diverging_cmap,
+                contour_level_count=contour_level_count,
+                contour_line_width=contour_line_width,
+                display_limits=display_limits,
+                dpi=dpi,
+                figure_size=figure_size,
+                plt=plt,
+                mcolors=mcolors,
+            )
+        )
+    return steps, images, resolved_vis_type
+
+
+def visualization_semantic_kwargs(variable: str, vis_type: str) -> dict[str, Any]:
+    """Map one variable to the semantic arguments used by Manager.visualization()."""
+    normalized_vis_type = normalize_vis_type(vis_type)
+    if normalized_vis_type == "streamlines":
+        return {"streamline_by": variable}
+    if normalized_vis_type == "contour":
+        return {"contour_by": variable}
+    if normalized_vis_type == "heatmap_contour":
+        return {"color_by": variable, "contour_by": variable}
+    if normalized_vis_type in {"line_plot", "line-plot", "timeseries"}:
+        return {"x_axis": "step", "y_axis": variable}
+    return {"color_by": variable}
+
+
+def visualization_name(variable: str, vis_type: str, explicit_name: str | None, variable_count: int) -> str:
+    """Return a stable visualization name for replace=True reruns."""
+    if explicit_name is not None:
+        if variable_count > 1:
+            raise SystemExit("--name can only be used with one --variable.")
+        return explicit_name
+    if normalize_vis_type(vis_type) == "streamlines":
+        target_name = normalize_streamline_target(variable)
+        if target_name is not None:
+            return target_name
+    return f"{variable}_{vis_type}".replace("/", "_").replace(" ", "_")
+
+
+def visualization_sequence_name(dataset_name: str, name: str) -> str:
+    """Return the full visualization sequence name used by Manager.visualization()."""
+    return name if "/" in name else f"{dataset_name}/visualizations/{name}"
+
+
+def _safe_relative_parts(path_text: str) -> list[str]:
+    """Convert a logical campaign path into safe relative filesystem parts."""
+    parts: list[str] = []
+    for raw in str(path_text or "").replace("\\", "/").split("/"):
+        part = raw.strip()
+        if not part or part in {".", ".."}:
+            continue
+        parts.append(part)
+    if not parts:
+        raise SystemExit(f"Cannot build output path from empty logical path: {path_text!r}")
+    return parts
+
+
+def write_png_images(
+    image_output_dir: Path,
+    sequence_name: str,
+    steps: list[int],
+    images: list[bytes],
+) -> list[Path]:
+    """Write rendered PNG bytes to deterministic files and return absolute paths."""
+    relative_dir = Path(*_safe_relative_parts(sequence_name))
+    output_dir = image_output_dir / relative_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    step_values = steps if len(steps) == len(images) else list(range(len(images)))
+    paths: list[Path] = []
+    for step_value, image in zip(step_values, images, strict=True):
+        path = output_dir / f"image.{int(step_value):06d}.png"
+        path.write_bytes(image)
+        paths.append(path)
+    return paths
+
+
+def add_legacy_image_sequence(
+    manager,
+    dataset_name: str,
+    name: str,
+    steps: list[int],
+    images: list[bytes | Path],
+    image_workdir: Path | None = None,
+) -> None:
+    """
+    Register rendered images with Manager.image() when Manager.visualization() is unavailable.
+
+    This preserves the old campaign behavior: images are named as children of
+    <dataset>/visualizations/<name>, but no explicit visualization metadata
+    tables are populated because this Manager implementation does not expose
+    that API.
+    """
+    sequence_name = visualization_sequence_name(dataset_name, name)
+    image_steps = steps if len(steps) == len(images) else list(range(len(images)))
+
+    if image_workdir is not None:
+        cwd = Path.cwd()
+        os.chdir(image_workdir)
+        try:
+            for step_value, image in zip(image_steps, images, strict=True):
+                logical_name = f"{sequence_name}/image.{int(step_value):06d}.png"
+                manager.image(image, name=logical_name, store=False)
+        finally:
+            os.chdir(cwd)
+        return
+
+    with tempfile.TemporaryDirectory(prefix="hpc_campaign_visualization_") as tmpdir:
+        tmp_path = Path(tmpdir)
+        for step_value, image in zip(image_steps, images, strict=True):
+            logical_name = f"{sequence_name}/image.{int(step_value):06d}.png"
+            if isinstance(image, (bytes, bytearray)):
+                image_path = tmp_path / f"image.{int(step_value):06d}.png"
+                image_path.write_bytes(image)
+            else:
+                image_path = Path(image)
+            manager.image(image_path, name=logical_name, store=True)
+
+
+def add_visualization(
+    manager,
+    dataset_name: str,
+    variable: str,
+    vis_type: str,
+    name: str,
+    steps: list[int],
+    images: list[bytes | Path],
+    replace: bool,
+    thumbnail_step: int,
+    image_workdir: Path | None = None,
+) -> int | None:
+    """Store or register rendered images with new visualization metadata."""
+    if not images:
+        raise SystemExit("No images were rendered.")
+    if thumbnail_step < 0 or thumbnail_step >= len(images):
+        raise SystemExit(f"--thumbnailStep must be in [0, {len(images) - 1}]")
+
+    image_steps = steps if len(steps) == len(images) else None
+
+    if not hasattr(manager, "visualization"):
+        add_legacy_image_sequence(
+            manager=manager,
+            dataset_name=dataset_name,
+            name=name,
+            steps=steps,
+            images=images,
+            image_workdir=image_workdir,
+        )
+        return None
+
+    cwd = Path.cwd()
+    if image_workdir is not None:
+        os.chdir(image_workdir)
+    try:
+        return manager.visualization(
+            images=images,
+            kind=vis_type,
+            source_dataset=dataset_name,
+            name=name,
+            steps=image_steps,
+            thumbnail_image=thumbnail_step,
+            store=False,
+            metadata={
+                "generated_by": Path(__file__).name,
+                "steps": steps,
+                "external_images": image_workdir is not None,
+            },
+            replace=replace,
+            **visualization_semantic_kwargs(variable, vis_type),
+        )
+    finally:
+        if image_workdir is not None:
+            os.chdir(cwd)
+
+
+def prepare_visualization_images(
+    rendered_images: list[bytes],
+    steps: list[int],
+    dataset_name: str,
+    name: str,
+    image_output_dir: Path | None,
+    external_images: bool,
+) -> tuple[list[bytes | Path], Path | None]:
+    """Optionally write PNGs and return the inputs for Manager.visualization()."""
+    if image_output_dir is None:
+        return (rendered_images, None)
+
+    sequence_name = visualization_sequence_name(dataset_name, name)
+    written_paths = write_png_images(image_output_dir, sequence_name, steps, rendered_images)
+    print(f"[ok] wrote PNG files: {written_paths[0].parent}")
+
+    if not external_images:
+        return (rendered_images, None)
+
+    relative_paths = [path.relative_to(image_output_dir) for path in written_paths]
+    return (relative_paths, image_output_dir)
+
+
+def selected_dataset_variables(
+    bp_path: Path,
+    requested_variables: list[str],
+    all_variables: bool,
+    vis_type: str,
+) -> list[str]:
+    """Return variables or streamline targets to render for one dataset."""
+    if not all_variables:
+        return requested_variables
+
+    discovered = discover_variables(bp_path)
+    if normalize_vis_type(vis_type) != "streamlines":
+        return discovered
+
+    targets = available_streamline_targets(discovered)
+    if not targets:
+        raise MissingVariableError(f"No streamline targets found in {bp_path}")
+    return targets
+
+
+def main() -> int:
+    args = parse_args()
+
+    exact_names = split_csv(args.dataset)
+    patterns = split_csv(args.datasetPattern)
+    variables = split_csv(args.variable)
+
+    data_root = args.data_root.expanduser().resolve() if args.data_root is not None else None
+    image_output_dir = args.imageOutputDir.expanduser().resolve() if args.imageOutputDir is not None else None
+    if args.externalImages and image_output_dir is None:
+        raise SystemExit("--externalImages requires --imageOutputDir.")
+    if image_output_dir is not None and not args.dryRun:
+        image_output_dir.mkdir(parents=True, exist_ok=True)
+
+    figure_size = (float(args.figureWidth), float(args.figureHeight))
+
+    manager_class, format_info_fn = _import_hpc_campaign()
+    manager = manager_class(archive=args.archive, campaign_store=args.campaign_store)
+    manager.open(create=False)
+
+    added = 0
+    skipped = 0
+    try:
+        info_data = manager.info(list_replicas=True, list_files=False)
+        if args.listDatasets:
+            if exact_names or patterns or args.allDatasets:
+                datasets = select_datasets(info_data, exact_names, patterns, args.allDatasets)
+            else:
+                datasets = live_adios_datasets(info_data)
+            list_dataset_names(datasets)
+            return 0
+
+        if args.allVariables and args.name is not None:
+            raise SystemExit("--name cannot be used with --allVariables.")
+        if not variables and not args.allVariables:
+            raise SystemExit("Select at least one variable with --variable or use --allVariables.")
+
+        datasets = select_datasets(info_data, exact_names, patterns, args.allDatasets)
+        print(f"[info] datasets : {len(datasets)}")
+        print(f"[info] variables: {'<all>' if args.allVariables else variables}")
+        print(f"[info] visType  : {normalize_vis_type(args.visType)}")
+
+        directory_map = build_directory_map(info_data)
+        for dataset in datasets:
+            bp_path = resolve_dataset_path(dataset, data_root, directory_map)
+            print(f"[info] dataset path: {bp_path}")
+            try:
+                dataset_variables = selected_dataset_variables(bp_path, variables, args.allVariables, args.visType)
+            except MissingVariableError as exc:
+                if args.skipMissing:
+                    print(f"[warn] skipped dataset: {exc}")
+                    skipped += 1
+                    continue
+                raise SystemExit(str(exc)) from exc
+
+            if args.dryRun:
+                for variable in dataset_variables:
+                    name = visualization_name(
+                        variable,
+                        normalize_vis_type(args.visType),
+                        args.name,
+                        len(dataset_variables),
+                    )
+                    print(f"[dry-run] {dataset.name} variable={variable} visualization={name}")
+                continue
+
+            for variable in dataset_variables:
+                try:
+                    steps, images, resolved_vis_type = render_images(
+                        dataset_name=dataset.name,
+                        variable=variable,
+                        bp_path=bp_path,
+                        step=args.step,
+                        all_steps=args.allSteps,
+                        vis_type=args.visType,
+                        cmap=args.cmap,
+                        diverging_cmap=args.divergingCmap,
+                        contour_level_count=args.contourLevels,
+                        contour_line_width=args.contourLineWidth,
+                        dpi=args.dpi,
+                        figure_size=figure_size,
+                    )
+                except MissingVariableError as exc:
+                    if args.skipMissing:
+                        print(f"[warn] skipped: {exc}")
+                        skipped += 1
+                        continue
+                    raise SystemExit(str(exc)) from exc
+
+                name = visualization_name(variable, resolved_vis_type, args.name, len(dataset_variables))
+                visualization_images, image_workdir = prepare_visualization_images(
+                    rendered_images=images,
+                    steps=steps,
+                    dataset_name=dataset.name,
+                    name=name,
+                    image_output_dir=image_output_dir,
+                    external_images=bool(args.externalImages),
+                )
+
+                visid = add_visualization(
+                    manager=manager,
+                    dataset_name=dataset.name,
+                    variable=variable,
+                    vis_type=resolved_vis_type,
+                    name=name,
+                    steps=steps,
+                    images=visualization_images,
+                    replace=args.replace,
+                    thumbnail_step=args.thumbnailStep,
+                    image_workdir=image_workdir,
+                )
+                sequence_name = visualization_sequence_name(dataset.name, name)
+                if visid is None:
+                    print(f"[ok] added image sequence name={sequence_name} images={len(images)}")
+                else:
+                    print(f"[ok] added visualization visid={visid} name={sequence_name} images={len(images)}")
+                added += 1
+
+        if args.showInfo:
+            print(format_info_fn(manager.info(list_replicas=False, list_files=False)))
+    finally:
+        manager.close()
+
+    print(f"[ok] done. visualizations={added} skipped={skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/mhd_orszag_tang/scripts/run_ensembles.py
+++ b/examples/mhd_orszag_tang/scripts/run_ensembles.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Run ensembles of Orszag-Tang simulations with varying solver/parameters."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def to_cli_args(options: dict[str, Any]) -> list[str]:
+    args: list[str] = []
+    for key, value in options.items():
+        if value is None:
+            continue
+
+        opt = f"--{key.replace('_', '-')}"
+
+        if key == "save_initial":
+            args.append("--save-initial" if bool(value) else "--no-save-initial")
+            continue
+
+        if isinstance(value, bool):
+            if value:
+                args.append(opt)
+            continue
+
+        args.extend([opt, str(value)])
+    return args
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run an Orszag-Tang ensemble")
+    parser.add_argument("--config", required=True, help="Path to JSON ensemble config")
+    parser.add_argument(
+        "--binary",
+        required=True,
+        help="Path to the ot_mhd executable",
+    )
+    parser.add_argument(
+        "--prepend_var_names",
+        "--prepend-var-names",
+        dest="prepend_var_names",
+        default=None,
+        help="Prefix to prepend to all ADIOS variable names for every run",
+    )
+    parser.add_argument(
+        "--fixed-dt",
+        "--fixed_dt",
+        dest="fixed_dt",
+        type=float,
+        default=None,
+        help="Override all runs with a fixed simulation timestep (disables CFL-based dt)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Override the ensemble output root directory",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print commands without running")
+    parser.add_argument("--keep-going", action="store_true", help="Continue after failed members")
+    parser.add_argument("--only", nargs="*", default=None, help="Run only selected case names")
+    parser.add_argument(
+        "--ranks",
+        type=int,
+        default=None,
+        help="Override MPI ranks for all runs (default: use per-run or config default)",
+    )
+    parser.add_argument(
+        "--render-images",
+        action="store_true",
+        help="After each successful run, call scripts/render_output_movies.py for that run output",
+    )
+    args = parser.parse_args()
+    if args.ranks is not None and args.ranks < 1:
+        parser.error("--ranks must be >= 1")
+    if args.fixed_dt is not None and args.fixed_dt <= 0.0:
+        parser.error("--fixed-dt must be > 0")
+
+    config_path = Path(args.config)
+    with config_path.open("r", encoding="utf-8") as f:
+        cfg = json.load(f)
+
+    base_dir = config_path.resolve().parent
+
+    binary_cfg = Path(args.binary)
+    binary = (binary_cfg if binary_cfg.is_absolute() else binary_cfg.resolve()).resolve()
+    render_script = (Path(__file__).resolve().parent / "render_output_movies.py").resolve()
+    mpi_launcher = str(cfg.get("mpi_launcher", "mpirun -n {ranks}"))
+    output_cfg = Path(args.output_dir) if args.output_dir is not None else Path(cfg.get("output_dir", "runs"))
+    ensemble_output_root = (output_cfg if output_cfg.is_absolute() else (base_dir / output_cfg)).resolve()
+    common = dict(cfg.get("common_args", {}))
+    runs = list(cfg.get("runs", []))
+
+    if not runs:
+        print("No runs in config", file=sys.stderr)
+        return 1
+
+    ensemble_output_root.mkdir(parents=True, exist_ok=True)
+
+    selected = set(args.only) if args.only else None
+
+    failures = 0
+    executed = 0
+
+    for run in runs:
+        name = run.get("name")
+        if not name:
+            print("Skipping entry without 'name'", file=sys.stderr)
+            continue
+
+        if selected and name not in selected:
+            continue
+
+        ranks = args.ranks if args.ranks is not None else int(run.get("ranks", cfg.get("default_ranks", 1)))
+        run_has_output_file = "output" in run
+        run_has_output_dir = "output_dir" in run
+        if run_has_output_file and run_has_output_dir:
+            print(f"Run '{name}' has both 'output' and 'output_dir'; pick one.", file=sys.stderr)
+            return 1
+
+        run_output = None
+        run_output_dir = None
+        if run_has_output_file:
+            run_output_cfg = Path(str(run["output"]))
+            run_output = (run_output_cfg if run_output_cfg.is_absolute() else (base_dir / run_output_cfg)).resolve()
+        else:
+            run_output_dir_cfg = Path(str(run.get("output_dir", ensemble_output_root / name)))
+            run_output_dir = (
+                run_output_dir_cfg if run_output_dir_cfg.is_absolute() else (base_dir / run_output_dir_cfg)
+            ).resolve()
+
+        per_run = {k: v for k, v in run.items() if k not in {"name", "ranks", "output", "output_dir", "mpi_launcher"}}
+        merged = dict(common)
+        merged.update(per_run)
+        if args.prepend_var_names is not None:
+            merged["prepend_var_names"] = args.prepend_var_names
+        if args.fixed_dt is not None:
+            merged["fixed_dt"] = args.fixed_dt
+        if run_output is not None:
+            merged["output"] = str(run_output)
+            render_output_dir = run_output.parent
+            render_bp_name = run_output.name
+        else:
+            assert run_output_dir is not None
+            merged["output_dir"] = str(run_output_dir)
+            render_output_dir = run_output_dir
+            render_bp_name = "output.bp"
+
+        base_cmd = [str(binary)] + to_cli_args(merged)
+
+        if ranks > 1:
+            launcher_tmpl = str(run.get("mpi_launcher", mpi_launcher))
+            launch_prefix = shlex.split(launcher_tmpl.format(ranks=ranks))
+            run_cmd = launch_prefix + base_cmd
+        else:
+            run_cmd = list(base_cmd)
+
+        executed += 1
+        printable = " ".join(shlex.quote(part) for part in run_cmd)
+        print(f"[{name}] {printable}")
+
+        render_cmd: list[str] = []
+        if args.render_images:
+            render_cmd = [
+                sys.executable,
+                str(render_script),
+                "--output-dir",
+                str(render_output_dir),
+                "--bp-name",
+                render_bp_name,
+            ]
+            render_printable = " ".join(shlex.quote(part) for part in render_cmd)
+            print(f"[{name}] post: {render_printable}")
+
+        if args.dry_run:
+            continue
+
+        run_result = subprocess.run(run_cmd)
+        if run_result.returncode != 0:
+            failures += 1
+            print(f"Run '{name}' failed with code {run_result.returncode}", file=sys.stderr)
+            if not args.keep_going:
+                return run_result.returncode
+            continue
+
+        if args.render_images:
+            render_result = subprocess.run(render_cmd)
+            if render_result.returncode != 0:
+                failures += 1
+                print(f"Image render for run '{name}' failed with code {render_result.returncode}", file=sys.stderr)
+                if not args.keep_going:
+                    return render_result.returncode
+
+    if executed == 0:
+        print("No runs selected", file=sys.stderr)
+        return 1
+
+    if failures:
+        print(f"Finished with {failures} failed run(s)", file=sys.stderr)
+        return 1
+
+    print("Ensemble completed successfully")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/mhd_orszag_tang/src/adios_writer.cpp
+++ b/examples/mhd_orszag_tang/src/adios_writer.cpp
@@ -1,0 +1,139 @@
+#include "adios_writer.hpp"
+
+#include <stdexcept>
+
+namespace ot {
+
+namespace {
+
+std::string with_var_prefix(const SimulationParams& params, const char* logical_name) {
+  return params.prepend_var_names + logical_name;
+}
+
+}  // namespace
+
+#ifdef OT_USE_MPI
+AdiosWriter::AdiosWriter(const SimulationParams& params,
+                         int global_nx,
+                         int global_ny,
+                         int local_ny,
+                         int y_offset,
+                         int rank,
+                         MPI_Comm comm)
+    : rank_(rank), adios_(comm), io_(adios_.DeclareIO("ot_io")) {
+#else
+AdiosWriter::AdiosWriter(const SimulationParams& params,
+                         int global_nx,
+                         int global_ny,
+                         int local_ny,
+                         int y_offset,
+                         int rank)
+    : rank_(rank), adios_(), io_(adios_.DeclareIO("ot_io")) {
+#endif
+  io_.SetEngine(params.adios_engine);
+
+  const adios2::Dims shape = {static_cast<std::size_t>(global_ny), static_cast<std::size_t>(global_nx)};
+  const adios2::Dims start = {static_cast<std::size_t>(y_offset), 0};
+  const adios2::Dims count = {static_cast<std::size_t>(local_ny), static_cast<std::size_t>(global_nx)};
+
+  rho_ = io_.DefineVariable<double>(with_var_prefix(params, "rho"), shape, start, count);
+  pressure_ = io_.DefineVariable<double>(with_var_prefix(params, "pressure"), shape, start, count);
+  vx_ = io_.DefineVariable<double>(with_var_prefix(params, "vx"), shape, start, count);
+  vy_ = io_.DefineVariable<double>(with_var_prefix(params, "vy"), shape, start, count);
+  vz_ = io_.DefineVariable<double>(with_var_prefix(params, "vz"), shape, start, count);
+  bx_ = io_.DefineVariable<double>(with_var_prefix(params, "bx"), shape, start, count);
+  by_ = io_.DefineVariable<double>(with_var_prefix(params, "by"), shape, start, count);
+  bz_ = io_.DefineVariable<double>(with_var_prefix(params, "bz"), shape, start, count);
+  speed_ = io_.DefineVariable<double>(with_var_prefix(params, "speed"), shape, start, count);
+  current_z_ = io_.DefineVariable<double>(with_var_prefix(params, "current_z"), shape, start, count);
+  if (params.output_psi) {
+    psi_ = io_.DefineVariable<double>(with_var_prefix(params, "psi"), shape, start, count);
+  }
+  if (params.output_m) {
+    mx_ = io_.DefineVariable<double>(with_var_prefix(params, "mx"), shape, start, count);
+    my_ = io_.DefineVariable<double>(with_var_prefix(params, "my"), shape, start, count);
+    mz_ = io_.DefineVariable<double>(with_var_prefix(params, "mz"), shape, start, count);
+  }
+  if (params.output_E) {
+    E_ = io_.DefineVariable<double>(with_var_prefix(params, "E"), shape, start, count);
+  }
+
+  step_ = io_.DefineVariable<int>(with_var_prefix(params, "step"));
+  time_ = io_.DefineVariable<double>(with_var_prefix(params, "time"));
+  mass_ = io_.DefineVariable<double>(with_var_prefix(params, "mass"));
+  kinetic_energy_ = io_.DefineVariable<double>(with_var_prefix(params, "kinetic_energy"));
+  magnetic_energy_ = io_.DefineVariable<double>(with_var_prefix(params, "magnetic_energy"));
+  internal_energy_ = io_.DefineVariable<double>(with_var_prefix(params, "internal_energy"));
+  total_energy_ = io_.DefineVariable<double>(with_var_prefix(params, "total_energy"));
+  mean_pressure_ = io_.DefineVariable<double>(with_var_prefix(params, "mean_pressure"));
+  max_speed_ = io_.DefineVariable<double>(with_var_prefix(params, "max_speed"));
+  current_abs_max_ = io_.DefineVariable<double>(with_var_prefix(params, "current_abs_max"));
+  current_rms_ = io_.DefineVariable<double>(with_var_prefix(params, "current_rms"));
+  divb_abs_max_ = io_.DefineVariable<double>(with_var_prefix(params, "divb_abs_max"));
+  divb_l2_ = io_.DefineVariable<double>(with_var_prefix(params, "divb_l2"));
+
+  engine_ = io_.Open(params.output_file, adios2::Mode::Write);
+}
+
+AdiosWriter::~AdiosWriter() {
+  close();
+}
+
+void AdiosWriter::write(int step,
+                        double time,
+                        const OutputFields& fields,
+                        const ScalarDiagnostics& diagnostics) {
+  if (closed_) {
+    throw std::runtime_error("ADIOS writer is closed");
+  }
+
+  engine_.BeginStep();
+  engine_.Put(rho_, fields.rho.data());
+  engine_.Put(pressure_, fields.pressure.data());
+  engine_.Put(vx_, fields.vx.data());
+  engine_.Put(vy_, fields.vy.data());
+  engine_.Put(vz_, fields.vz.data());
+  engine_.Put(bx_, fields.bx.data());
+  engine_.Put(by_, fields.by.data());
+  engine_.Put(bz_, fields.bz.data());
+  engine_.Put(speed_, fields.speed.data());
+  engine_.Put(current_z_, fields.current_z.data());
+  if (psi_) {
+    engine_.Put(*psi_, fields.psi.data());
+  }
+  if (mx_) {
+    engine_.Put(*mx_, fields.mx.data());
+    engine_.Put(*my_, fields.my.data());
+    engine_.Put(*mz_, fields.mz.data());
+  }
+  if (E_) {
+    engine_.Put(*E_, fields.E.data());
+  }
+
+  if (rank_ == 0) {
+    engine_.Put(step_, step);
+    engine_.Put(time_, time);
+    engine_.Put(mass_, diagnostics.mass);
+    engine_.Put(kinetic_energy_, diagnostics.kinetic_energy);
+    engine_.Put(magnetic_energy_, diagnostics.magnetic_energy);
+    engine_.Put(internal_energy_, diagnostics.internal_energy);
+    engine_.Put(total_energy_, diagnostics.total_energy);
+    engine_.Put(mean_pressure_, diagnostics.mean_pressure);
+    engine_.Put(max_speed_, diagnostics.max_speed);
+    engine_.Put(current_abs_max_, diagnostics.current_abs_max);
+    engine_.Put(current_rms_, diagnostics.current_rms);
+    engine_.Put(divb_abs_max_, diagnostics.divb_abs_max);
+    engine_.Put(divb_l2_, diagnostics.divb_l2);
+  }
+
+  engine_.EndStep();
+}
+
+void AdiosWriter::close() {
+  if (!closed_) {
+    engine_.Close();
+    closed_ = true;
+  }
+}
+
+}  // namespace ot

--- a/examples/mhd_orszag_tang/src/adios_writer.hpp
+++ b/examples/mhd_orszag_tang/src/adios_writer.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <adios2.h>
+#include <optional>
+
+#include "mhd2d.hpp"
+
+#ifdef OT_USE_MPI
+#include <mpi.h>
+#endif
+
+namespace ot {
+
+class AdiosWriter {
+ public:
+#ifdef OT_USE_MPI
+  AdiosWriter(const SimulationParams& params,
+              int global_nx,
+              int global_ny,
+              int local_ny,
+              int y_offset,
+              int rank,
+              MPI_Comm comm);
+#else
+  AdiosWriter(const SimulationParams& params,
+              int global_nx,
+              int global_ny,
+              int local_ny,
+              int y_offset,
+              int rank);
+#endif
+
+  ~AdiosWriter();
+
+  void write(int step, double time, const OutputFields& fields, const ScalarDiagnostics& diagnostics);
+  void close();
+
+ private:
+  int rank_ = 0;
+  bool closed_ = false;
+
+  adios2::ADIOS adios_;
+  adios2::IO io_;
+  adios2::Engine engine_;
+
+  adios2::Variable<double> rho_;
+  adios2::Variable<double> pressure_;
+  adios2::Variable<double> vx_;
+  adios2::Variable<double> vy_;
+  adios2::Variable<double> vz_;
+  adios2::Variable<double> bx_;
+  adios2::Variable<double> by_;
+  adios2::Variable<double> bz_;
+  adios2::Variable<double> speed_;
+  adios2::Variable<double> current_z_;
+  std::optional<adios2::Variable<double>> psi_;
+  std::optional<adios2::Variable<double>> mx_;
+  std::optional<adios2::Variable<double>> my_;
+  std::optional<adios2::Variable<double>> mz_;
+  std::optional<adios2::Variable<double>> E_;
+
+  adios2::Variable<int> step_;
+  adios2::Variable<double> time_;
+  adios2::Variable<double> mass_;
+  adios2::Variable<double> kinetic_energy_;
+  adios2::Variable<double> magnetic_energy_;
+  adios2::Variable<double> internal_energy_;
+  adios2::Variable<double> total_energy_;
+  adios2::Variable<double> mean_pressure_;
+  adios2::Variable<double> max_speed_;
+  adios2::Variable<double> current_abs_max_;
+  adios2::Variable<double> current_rms_;
+  adios2::Variable<double> divb_abs_max_;
+  adios2::Variable<double> divb_l2_;
+};
+
+}  // namespace ot

--- a/examples/mhd_orszag_tang/src/main.cpp
+++ b/examples/mhd_orszag_tang/src/main.cpp
@@ -1,0 +1,501 @@
+#include "adios_writer.hpp"
+#include "mhd2d.hpp"
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+#ifdef OT_USE_MPI
+#include <mpi.h>
+#endif
+
+namespace {
+
+void print_usage(const char* prog) {
+  std::cout << "Usage: " << prog << " [options]\n\n"
+            << "Core options:\n"
+            << "  --nx <int>                    Global x resolution (default 256)\n"
+            << "  --ny <int>                    Global y resolution (default 256)\n"
+            << "  --tfinal <float>              Final simulation time (default 1.0)\n"
+            << "  --cfl <float>                 CFL number (default 0.35)\n"
+            << "  --gamma <float>               Ratio of specific heats (default 5/3)\n"
+            << "  --solver <name>               rusanov|hll|muscl_hll|muscl_rusanov\n"
+            << "  --flux <name>                 rusanov|hll (optional override)\n"
+            << "  --reconstruction <name>       first|muscl (optional override)\n"
+            << "\nOutput options:\n"
+            << "  --output <path>               ADIOS2 BP output file (default output/output.bp)\n"
+            << "  --output-dir <path>           Run output directory (writes <path>/output.bp)\n"
+            << "  --engine <name>               ADIOS2 engine (default BP5)\n"
+            << "  --prepend-var-names <str>     Prefix added to all ADIOS variable names\n"
+            << "  --fixed-dt <float>            Fixed timestep (overrides CFL-based dt)\n"
+            << "  --psi                         Output the GLM cleaning field psi\n"
+            << "  --m                           Output momentum fields mx,my,mz\n"
+            << "  --E                           Output total energy density field E\n"
+            << "  --output-every-steps <int>    Save every N steps (0 disables)\n"
+            << "  --output-every-time <float>   Save every Dt in sim time (0 disables)\n"
+            << "  --save-initial                Save initial state (default true)\n"
+            << "  --no-save-initial             Skip initial output\n"
+            << "\nStability / control options:\n"
+            << "  --rho-floor <float>           Density floor\n"
+            << "  --p-floor <float>             Pressure floor\n"
+            << "  --glm-ch <float>              GLM propagation speed\n"
+            << "  --glm-damping <float>         GLM damping coefficient\n"
+            << "  --max-steps <int>             Hard step limit\n"
+            << "  --log-every-steps <int>       Print progress every N steps\n"
+            << "  --help                        Show this help\n";
+}
+
+bool parse_int_arg(const std::string& arg, int& out) {
+  try {
+    out = std::stoi(arg);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+bool parse_double_arg(const std::string& arg, double& out) {
+  try {
+    out = std::stod(arg);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+std::string next_value(int& i, int argc, char** argv, const std::string& opt) {
+  if (i + 1 >= argc) {
+    throw std::runtime_error("Missing value for option " + opt);
+  }
+  ++i;
+  return argv[i];
+}
+
+void write_input_parameters(const std::filesystem::path& params_file,
+                            const std::filesystem::path& output_dir,
+                            const ot::SimulationParams& params) {
+  std::ofstream out(params_file);
+  if (!out) {
+    throw std::runtime_error("Failed to open parameter file: " + params_file.string());
+  }
+
+  out << std::boolalpha << std::setprecision(17);
+  out << "nx=" << params.nx << "\n";
+  out << "ny=" << params.ny << "\n";
+  out << "ng=" << params.ng << "\n";
+  out << "tfinal=" << params.tfinal << "\n";
+  out << "cfl=" << params.cfl << "\n";
+  out << "gamma=" << params.gamma << "\n";
+  out << "x_min=" << params.x_min << "\n";
+  out << "x_max=" << params.x_max << "\n";
+  out << "y_min=" << params.y_min << "\n";
+  out << "y_max=" << params.y_max << "\n";
+  out << "solver=" << ot::reconstruction_to_string(params.reconstruction) << "+"
+      << ot::flux_to_string(params.flux) << "\n";
+  out << "flux=" << ot::flux_to_string(params.flux) << "\n";
+  out << "reconstruction=" << ot::reconstruction_to_string(params.reconstruction) << "\n";
+  out << "rho_floor=" << params.rho_floor << "\n";
+  out << "p_floor=" << params.p_floor << "\n";
+  out << "glm_ch=" << params.glm_ch << "\n";
+  out << "glm_damping=" << params.glm_damping << "\n";
+  out << "max_steps=" << params.max_steps << "\n";
+  out << "log_every_steps=" << params.log_every_steps << "\n";
+  out << "adios_engine=" << params.adios_engine << "\n";
+  out << "prepend_var_names=" << params.prepend_var_names << "\n";
+  out << "fixed_dt=" << params.fixed_dt << "\n";
+  out << "output_psi=" << params.output_psi << "\n";
+  out << "output_m=" << params.output_m << "\n";
+  out << "output_E=" << params.output_E << "\n";
+  out << "output_every_steps=" << params.output_every_steps << "\n";
+  out << "output_every_time=" << params.output_every_time << "\n";
+  out << "save_initial=" << params.save_initial << "\n";
+  out << "output_dir=" << output_dir.string() << "\n";
+  out << "output_file=" << params.output_file << "\n";
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+#ifdef OT_USE_MPI
+  MPI_Init(&argc, &argv);
+  MPI_Comm comm = MPI_COMM_WORLD;
+  int rank = 0;
+  MPI_Comm_rank(comm, &rank);
+#else
+  int rank = 0;
+#endif
+
+  try {
+    ot::SimulationParams params;
+    bool output_file_set = false;
+    bool output_dir_set = false;
+    std::filesystem::path output_dir_arg;
+
+    for (int i = 1; i < argc; ++i) {
+      const std::string arg = argv[i];
+
+      if (arg == "--help") {
+        if (rank == 0) {
+          print_usage(argv[0]);
+        }
+#ifdef OT_USE_MPI
+        MPI_Finalize();
+#endif
+        return 0;
+      }
+      if (arg == "--nx") {
+        int v = 0;
+        if (!parse_int_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid integer for --nx");
+        }
+        params.nx = v;
+        continue;
+      }
+      if (arg == "--ny") {
+        int v = 0;
+        if (!parse_int_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid integer for --ny");
+        }
+        params.ny = v;
+        continue;
+      }
+      if (arg == "--tfinal") {
+        double v = 0.0;
+        if (!parse_double_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid float for --tfinal");
+        }
+        params.tfinal = v;
+        continue;
+      }
+      if (arg == "--cfl") {
+        double v = 0.0;
+        if (!parse_double_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid float for --cfl");
+        }
+        params.cfl = v;
+        continue;
+      }
+      if (arg == "--gamma") {
+        double v = 0.0;
+        if (!parse_double_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid float for --gamma");
+        }
+        params.gamma = v;
+        continue;
+      }
+      if (arg == "--solver") {
+        const std::string solver_name = next_value(i, argc, argv, arg);
+        if (!ot::parse_solver_name(solver_name, params.flux, params.reconstruction)) {
+          throw std::runtime_error("Unknown solver: " + solver_name);
+        }
+        continue;
+      }
+      if (arg == "--flux") {
+        const std::string flux_name = next_value(i, argc, argv, arg);
+        if (flux_name == "rusanov") {
+          params.flux = ot::FluxType::Rusanov;
+        } else if (flux_name == "hll") {
+          params.flux = ot::FluxType::HLL;
+        } else {
+          throw std::runtime_error("Unknown flux: " + flux_name);
+        }
+        continue;
+      }
+      if (arg == "--reconstruction") {
+        const std::string recon_name = next_value(i, argc, argv, arg);
+        if (recon_name == "first" || recon_name == "first_order") {
+          params.reconstruction = ot::ReconstructionType::FirstOrder;
+        } else if (recon_name == "muscl") {
+          params.reconstruction = ot::ReconstructionType::MUSCL;
+        } else {
+          throw std::runtime_error("Unknown reconstruction: " + recon_name);
+        }
+        continue;
+      }
+      if (arg == "--output") {
+        params.output_file = next_value(i, argc, argv, arg);
+        output_file_set = true;
+        continue;
+      }
+      if (arg == "--output-dir") {
+        output_dir_arg = next_value(i, argc, argv, arg);
+        output_dir_set = true;
+        continue;
+      }
+      if (arg == "--engine") {
+        params.adios_engine = next_value(i, argc, argv, arg);
+        continue;
+      }
+      if (arg == "--prepend-var-names" || arg == "--prepend_var_names") {
+        params.prepend_var_names = next_value(i, argc, argv, arg);
+        continue;
+      }
+      if (arg == "--fixed-dt" || arg == "--fixed_dt") {
+        double v = 0.0;
+        if (!parse_double_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid float for --fixed-dt");
+        }
+        params.fixed_dt = v;
+        continue;
+      }
+      if (arg == "--psi") {
+        params.output_psi = true;
+        continue;
+      }
+      if (arg == "--m") {
+        params.output_m = true;
+        continue;
+      }
+      if (arg == "--E" || arg == "--e") {
+        params.output_E = true;
+        continue;
+      }
+      if (arg == "--output-every-steps") {
+        int v = 0;
+        if (!parse_int_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid integer for --output-every-steps");
+        }
+        params.output_every_steps = v;
+        continue;
+      }
+      if (arg == "--output-every-time") {
+        double v = 0.0;
+        if (!parse_double_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid float for --output-every-time");
+        }
+        params.output_every_time = v;
+        continue;
+      }
+      if (arg == "--save-initial") {
+        params.save_initial = true;
+        continue;
+      }
+      if (arg == "--no-save-initial") {
+        params.save_initial = false;
+        continue;
+      }
+      if (arg == "--rho-floor") {
+        double v = 0.0;
+        if (!parse_double_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid float for --rho-floor");
+        }
+        params.rho_floor = v;
+        continue;
+      }
+      if (arg == "--p-floor") {
+        double v = 0.0;
+        if (!parse_double_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid float for --p-floor");
+        }
+        params.p_floor = v;
+        continue;
+      }
+      if (arg == "--glm-ch") {
+        double v = 0.0;
+        if (!parse_double_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid float for --glm-ch");
+        }
+        params.glm_ch = v;
+        continue;
+      }
+      if (arg == "--glm-damping") {
+        double v = 0.0;
+        if (!parse_double_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid float for --glm-damping");
+        }
+        params.glm_damping = v;
+        continue;
+      }
+      if (arg == "--max-steps") {
+        int v = 0;
+        if (!parse_int_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid integer for --max-steps");
+        }
+        params.max_steps = v;
+        continue;
+      }
+      if (arg == "--log-every-steps") {
+        int v = 0;
+        if (!parse_int_arg(next_value(i, argc, argv, arg), v)) {
+          throw std::runtime_error("Invalid integer for --log-every-steps");
+        }
+        params.log_every_steps = v;
+        continue;
+      }
+
+      throw std::runtime_error("Unknown option: " + arg);
+    }
+
+    if (params.nx <= 4 || params.ny <= 4) {
+      throw std::runtime_error("nx and ny must be > 4");
+    }
+    if (params.cfl <= 0.0) {
+      throw std::runtime_error("cfl must be > 0");
+    }
+    if (params.tfinal <= 0.0) {
+      throw std::runtime_error("tfinal must be > 0");
+    }
+    if (params.output_every_steps < 0 || params.output_every_time < 0.0) {
+      throw std::runtime_error("output cadence values must be non-negative");
+    }
+    if (params.fixed_dt < 0.0) {
+      throw std::runtime_error("fixed_dt must be non-negative");
+    }
+
+    if (output_file_set && output_dir_set) {
+      throw std::runtime_error("Use either --output or --output-dir, not both");
+    }
+
+    std::filesystem::path run_output_dir;
+    if (output_dir_set) {
+      run_output_dir = output_dir_arg;
+      params.output_file = (run_output_dir / "output.bp").string();
+    } else {
+      const std::filesystem::path explicit_output(params.output_file);
+      run_output_dir = explicit_output.has_parent_path() ? explicit_output.parent_path()
+                                                         : std::filesystem::path(".");
+    }
+
+    const std::filesystem::path output_path(params.output_file);
+    const std::filesystem::path params_file = run_output_dir / "input_parameters.txt";
+    if (rank == 0) {
+      std::filesystem::create_directories(run_output_dir);
+      if (output_path.has_parent_path()) {
+        std::filesystem::create_directories(output_path.parent_path());
+      }
+      write_input_parameters(params_file, run_output_dir, params);
+    }
+#ifdef OT_USE_MPI
+    MPI_Barrier(comm);
+#endif
+
+#ifdef OT_USE_MPI
+    ot::MHD2D sim(params, comm);
+#else
+    ot::MHD2D sim(params);
+#endif
+    sim.initialize_orszag_tang();
+
+#ifdef OT_USE_MPI
+    ot::AdiosWriter writer(params,
+                           sim.global_nx(),
+                           sim.global_ny(),
+                           sim.local_ny(),
+                           sim.y_offset(),
+                           sim.rank(),
+                           comm);
+#else
+    ot::AdiosWriter writer(params,
+                           sim.global_nx(),
+                           sim.global_ny(),
+                           sim.local_ny(),
+                           sim.y_offset(),
+                           sim.rank());
+#endif
+
+    if (rank == 0) {
+      std::cout << std::setprecision(6) << std::fixed;
+      std::cout << "Running Orszag-Tang MHD\n"
+                << "  Grid: " << params.nx << " x " << params.ny << "\n"
+                << "  Solver: " << ot::reconstruction_to_string(params.reconstruction)
+                << "+" << ot::flux_to_string(params.flux) << "\n"
+                << "  tfinal: " << params.tfinal << ", CFL: " << params.cfl << "\n"
+                << "  Output: " << params.output_file << " (" << params.adios_engine << ")\n";
+      if (!params.prepend_var_names.empty()) {
+        std::cout << "  Variable prefix: " << params.prepend_var_names << "\n";
+      }
+      if (params.fixed_dt > 0.0) {
+        std::cout << "  Fixed dt: " << params.fixed_dt << "\n";
+      }
+      if (params.output_psi || params.output_m || params.output_E) {
+        std::cout << "  Extra outputs:";
+        if (params.output_psi) {
+          std::cout << " psi";
+        }
+        if (params.output_m) {
+          std::cout << " mx,my,mz";
+        }
+        if (params.output_E) {
+          std::cout << " E";
+        }
+        std::cout << "\n";
+      }
+    }
+
+    double t = 0.0;
+    int step = 0;
+
+    if (params.save_initial) {
+      ot::OutputFields fields;
+      ot::ScalarDiagnostics diagnostics;
+      sim.extract_output(fields);
+      sim.compute_diagnostics(diagnostics);
+      writer.write(step, t, fields, diagnostics);
+    }
+
+    const double no_time_cadence = std::numeric_limits<double>::infinity();
+    double next_time_dump = params.output_every_time > 0.0 ? params.output_every_time : no_time_cadence;
+
+    while (t < params.tfinal && step < params.max_steps) {
+      double dt = sim.compute_time_step();
+      if (!std::isfinite(dt) || dt <= 0.0) {
+        throw std::runtime_error("Non-finite or non-positive dt computed");
+      }
+      if (t + dt > params.tfinal) {
+        dt = params.tfinal - t;
+      }
+
+      sim.advance(dt);
+      t += dt;
+      ++step;
+
+      const bool due_step = (params.output_every_steps > 0) && (step % params.output_every_steps == 0);
+      bool due_time = false;
+      if (params.output_every_time > 0.0 && t + 1.0e-14 >= next_time_dump) {
+        due_time = true;
+        while (t + 1.0e-14 >= next_time_dump) {
+          next_time_dump += params.output_every_time;
+        }
+      }
+
+      const bool final_dump = (t + 1.0e-14 >= params.tfinal);
+      if (due_step || due_time || final_dump) {
+        ot::OutputFields fields;
+        ot::ScalarDiagnostics diagnostics;
+        sim.extract_output(fields);
+        sim.compute_diagnostics(diagnostics);
+        writer.write(step, t, fields, diagnostics);
+      }
+
+      if (rank == 0 && params.log_every_steps > 0 && step % params.log_every_steps == 0) {
+        std::cout << "step=" << step << " t=" << t << " dt=" << dt << "\n";
+      }
+    }
+
+    if (rank == 0) {
+      std::cout << "Completed: steps=" << step << " t=" << t << "\n";
+      if (step >= params.max_steps && t < params.tfinal) {
+        std::cout << "Stopped at max_steps before tfinal\n";
+      }
+    }
+
+    writer.close();
+
+#ifdef OT_USE_MPI
+    MPI_Finalize();
+#endif
+    return 0;
+
+  } catch (const std::exception& ex) {
+    std::cerr << "Error: " << ex.what() << "\n";
+#ifdef OT_USE_MPI
+    MPI_Finalize();
+#endif
+    return 1;
+  }
+}

--- a/examples/mhd_orszag_tang/src/mhd2d.cpp
+++ b/examples/mhd_orszag_tang/src/mhd2d.cpp
@@ -1,0 +1,765 @@
+#include "mhd2d.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cctype>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace ot {
+
+namespace {
+
+double clamp_floor(double v, double floor) {
+  return std::isfinite(v) ? std::max(v, floor) : floor;
+}
+
+}  // namespace
+
+#ifdef OT_USE_MPI
+MHD2D::MHD2D(const SimulationParams& params, MPI_Comm comm)
+    : params_(params), comm_(comm) {
+  MPI_Comm_rank(comm_, &rank_);
+  MPI_Comm_size(comm_, &size_);
+
+  if (params_.ny < size_) {
+    throw std::runtime_error("ny must be >= MPI size for this 1D decomposition");
+  }
+
+  const int base = params_.ny / size_;
+  const int rem = params_.ny % size_;
+  local_ny_ = base + (rank_ < rem ? 1 : 0);
+  y_offset_ = rank_ * base + std::min(rank_, rem);
+
+  if (local_ny_ <= 0) {
+    throw std::runtime_error("local_ny must be positive on all ranks");
+  }
+
+  nx_tot_ = params_.nx + 2 * params_.ng;
+  ny_tot_ = local_ny_ + 2 * params_.ng;
+
+  dx_ = (params_.x_max - params_.x_min) / static_cast<double>(params_.nx);
+  dy_ = (params_.y_max - params_.y_min) / static_cast<double>(params_.ny);
+
+  const std::size_t total = static_cast<std::size_t>(kNumVars) * nx_tot_ * ny_tot_;
+  u_.assign(total, 0.0);
+  rhs_.assign(total, 0.0);
+  stage_.assign(total, 0.0);
+  rhs_stage_.assign(total, 0.0);
+}
+#else
+MHD2D::MHD2D(const SimulationParams& params) : params_(params) {
+  local_ny_ = params_.ny;
+  y_offset_ = 0;
+
+  nx_tot_ = params_.nx + 2 * params_.ng;
+  ny_tot_ = local_ny_ + 2 * params_.ng;
+
+  dx_ = (params_.x_max - params_.x_min) / static_cast<double>(params_.nx);
+  dy_ = (params_.y_max - params_.y_min) / static_cast<double>(params_.ny);
+
+  const std::size_t total = static_cast<std::size_t>(kNumVars) * nx_tot_ * ny_tot_;
+  u_.assign(total, 0.0);
+  rhs_.assign(total, 0.0);
+  stage_.assign(total, 0.0);
+  rhs_stage_.assign(total, 0.0);
+}
+#endif
+
+int MHD2D::idx(int v, int i, int j) const {
+  return (v * ny_tot_ + j) * nx_tot_ + i;
+}
+
+double MHD2D::at(const std::vector<double>& u, int v, int i, int j) const {
+  return u[idx(v, i, j)];
+}
+
+double& MHD2D::at(std::vector<double>& u, int v, int i, int j) const {
+  return u[idx(v, i, j)];
+}
+
+MHD2D::State MHD2D::load_state(const std::vector<double>& u, int i, int j) const {
+  State s{};
+  for (int v = 0; v < kNumVars; ++v) {
+    s[v] = at(u, v, i, j);
+  }
+  return s;
+}
+
+void MHD2D::store_state(std::vector<double>& u, int i, int j, const State& s) const {
+  for (int v = 0; v < kNumVars; ++v) {
+    at(u, v, i, j) = s[v];
+  }
+}
+
+MHD2D::Primitive MHD2D::conserved_to_primitive(const State& s) const {
+  Primitive w{};
+  w.rho = clamp_floor(s[kRho], params_.rho_floor);
+
+  w.bx = std::isfinite(s[kBx]) ? s[kBx] : 0.0;
+  w.by = std::isfinite(s[kBy]) ? s[kBy] : 0.0;
+  w.bz = std::isfinite(s[kBz]) ? s[kBz] : 0.0;
+  w.psi = std::isfinite(s[kPsi]) ? s[kPsi] : 0.0;
+
+  w.vx = std::isfinite(s[kMx]) ? s[kMx] / w.rho : 0.0;
+  w.vy = std::isfinite(s[kMy]) ? s[kMy] / w.rho : 0.0;
+  w.vz = std::isfinite(s[kMz]) ? s[kMz] / w.rho : 0.0;
+
+  const double v2 = w.vx * w.vx + w.vy * w.vy + w.vz * w.vz;
+  const double b2 = w.bx * w.bx + w.by * w.by + w.bz * w.bz;
+  const double kin = 0.5 * w.rho * v2;
+  const double mag = 0.5 * b2;
+
+  const double eint = s[kE] - kin - mag;
+  w.p = clamp_floor((params_.gamma - 1.0) * eint, params_.p_floor);
+  return w;
+}
+
+MHD2D::State MHD2D::primitive_to_conserved(const Primitive& w) const {
+  State s{};
+  const double rho = clamp_floor(w.rho, params_.rho_floor);
+  const double p = clamp_floor(w.p, params_.p_floor);
+
+  s[kRho] = rho;
+  s[kMx] = rho * w.vx;
+  s[kMy] = rho * w.vy;
+  s[kMz] = rho * w.vz;
+  s[kBx] = w.bx;
+  s[kBy] = w.by;
+  s[kBz] = w.bz;
+
+  const double v2 = w.vx * w.vx + w.vy * w.vy + w.vz * w.vz;
+  const double b2 = w.bx * w.bx + w.by * w.by + w.bz * w.bz;
+  s[kE] = p / (params_.gamma - 1.0) + 0.5 * rho * v2 + 0.5 * b2;
+  s[kPsi] = w.psi;
+  return s;
+}
+
+MHD2D::State MHD2D::flux(const State& s, int dir) const {
+  const Primitive w = conserved_to_primitive(s);
+
+  State f{};
+  const double b2 = w.bx * w.bx + w.by * w.by + w.bz * w.bz;
+  const double ptot = w.p + 0.5 * b2;
+  const double vdotb = w.vx * w.bx + w.vy * w.by + w.vz * w.bz;
+  const double ch2 = params_.glm_ch * params_.glm_ch;
+
+  if (dir == 0) {
+    f[kRho] = s[kMx];
+    f[kMx] = s[kMx] * w.vx + ptot - w.bx * w.bx;
+    f[kMy] = s[kMy] * w.vx - w.bx * w.by;
+    f[kMz] = s[kMz] * w.vx - w.bx * w.bz;
+
+    f[kBx] = w.psi;
+    f[kBy] = w.vx * w.by - w.vy * w.bx;
+    f[kBz] = w.vx * w.bz - w.vz * w.bx;
+
+    f[kE] = (s[kE] + ptot) * w.vx - vdotb * w.bx;
+    f[kPsi] = ch2 * w.bx;
+  } else {
+    f[kRho] = s[kMy];
+    f[kMx] = s[kMx] * w.vy - w.by * w.bx;
+    f[kMy] = s[kMy] * w.vy + ptot - w.by * w.by;
+    f[kMz] = s[kMz] * w.vy - w.by * w.bz;
+
+    f[kBx] = w.vy * w.bx - w.vx * w.by;
+    f[kBy] = w.psi;
+    f[kBz] = w.vy * w.bz - w.vz * w.by;
+
+    f[kE] = (s[kE] + ptot) * w.vy - vdotb * w.by;
+    f[kPsi] = ch2 * w.by;
+  }
+
+  return f;
+}
+
+double MHD2D::fast_magnetosonic(const Primitive& w, int dir) const {
+  const double rho = std::max(w.rho, 1.0e-30);
+  const double inv_rho = 1.0 / rho;
+  const double a2 = params_.gamma * std::max(w.p, 0.0) * inv_rho;
+  const double b2 = (w.bx * w.bx + w.by * w.by + w.bz * w.bz) * inv_rho;
+  const double bn = (dir == 0 ? w.bx : w.by);
+  const double bn2 = bn * bn * inv_rho;
+  double disc = (a2 + b2) * (a2 + b2) - 4.0 * a2 * bn2;
+  disc = std::max(disc, 0.0);
+  const double cf2 = 0.5 * ((a2 + b2) + std::sqrt(disc));
+  return std::sqrt(std::max(cf2, 0.0));
+}
+
+double MHD2D::signal_speed(const State& s, int dir) const {
+  const Primitive w = conserved_to_primitive(s);
+  const double vn = (dir == 0 ? w.vx : w.vy);
+  const double cf = fast_magnetosonic(w, dir);
+  return std::abs(vn) + cf;
+}
+
+MHD2D::State MHD2D::riemann_flux(const State& left, const State& right, int dir) const {
+  const State fl = flux(left, dir);
+  const State fr = flux(right, dir);
+
+  State out{};
+
+  if (params_.flux == FluxType::Rusanov) {
+    const double alpha = std::max(signal_speed(left, dir), signal_speed(right, dir));
+    for (int v = 0; v < kNumVars; ++v) {
+      out[v] = 0.5 * (fl[v] + fr[v]) - 0.5 * alpha * (right[v] - left[v]);
+    }
+    return out;
+  }
+
+  const Primitive wl = conserved_to_primitive(left);
+  const Primitive wr = conserved_to_primitive(right);
+
+  const double vn_l = (dir == 0 ? wl.vx : wl.vy);
+  const double vn_r = (dir == 0 ? wr.vx : wr.vy);
+
+  const double cf_l = fast_magnetosonic(wl, dir);
+  const double cf_r = fast_magnetosonic(wr, dir);
+
+  const double s_l = std::min(vn_l - cf_l, vn_r - cf_r);
+  const double s_r = std::max(vn_l + cf_l, vn_r + cf_r);
+
+  if (s_l >= 0.0) {
+    return fl;
+  }
+  if (s_r <= 0.0) {
+    return fr;
+  }
+
+  const double inv = 1.0 / (s_r - s_l);
+  for (int v = 0; v < kNumVars; ++v) {
+    out[v] = (s_r * fl[v] - s_l * fr[v] + s_l * s_r * (right[v] - left[v])) * inv;
+  }
+  return out;
+}
+
+double MHD2D::minmod(double a, double b) {
+  if (a * b <= 0.0) {
+    return 0.0;
+  }
+  return (std::abs(a) < std::abs(b)) ? a : b;
+}
+
+void MHD2D::fill_boundaries(std::vector<double>& u) const {
+  const int ng = params_.ng;
+
+  // x periodic boundaries (local).
+  for (int v = 0; v < kNumVars; ++v) {
+    for (int j = 0; j < ny_tot_; ++j) {
+      for (int g = 0; g < ng; ++g) {
+        at(u, v, g, j) = at(u, v, params_.nx + g, j);
+        at(u, v, ng + params_.nx + g, j) = at(u, v, ng + g, j);
+      }
+    }
+  }
+
+#ifdef OT_USE_MPI
+  if (size_ > 1) {
+    const int prev = (rank_ - 1 + size_) % size_;
+    const int next = (rank_ + 1) % size_;
+
+    const int count = kNumVars * ng * nx_tot_;
+
+    std::vector<double> send_bottom(count, 0.0);
+    std::vector<double> send_top(count, 0.0);
+    std::vector<double> recv_bottom(count, 0.0);
+    std::vector<double> recv_top(count, 0.0);
+
+    int c = 0;
+    for (int v = 0; v < kNumVars; ++v) {
+      for (int g = 0; g < ng; ++g) {
+        const int j = ng + g;
+        for (int i = 0; i < nx_tot_; ++i) {
+          send_bottom[c++] = at(u, v, i, j);
+        }
+      }
+    }
+
+    c = 0;
+    for (int v = 0; v < kNumVars; ++v) {
+      for (int g = 0; g < ng; ++g) {
+        const int j = local_ny_ + g;
+        for (int i = 0; i < nx_tot_; ++i) {
+          send_top[c++] = at(u, v, i, j);
+        }
+      }
+    }
+
+    MPI_Sendrecv(send_bottom.data(), count, MPI_DOUBLE, prev, 101,
+                 recv_top.data(), count, MPI_DOUBLE, next, 101,
+                 comm_, MPI_STATUS_IGNORE);
+
+    MPI_Sendrecv(send_top.data(), count, MPI_DOUBLE, next, 102,
+                 recv_bottom.data(), count, MPI_DOUBLE, prev, 102,
+                 comm_, MPI_STATUS_IGNORE);
+
+    c = 0;
+    for (int v = 0; v < kNumVars; ++v) {
+      for (int g = 0; g < ng; ++g) {
+        const int j = g;
+        for (int i = 0; i < nx_tot_; ++i) {
+          at(u, v, i, j) = recv_bottom[c++];
+        }
+      }
+    }
+
+    c = 0;
+    for (int v = 0; v < kNumVars; ++v) {
+      for (int g = 0; g < ng; ++g) {
+        const int j = ng + local_ny_ + g;
+        for (int i = 0; i < nx_tot_; ++i) {
+          at(u, v, i, j) = recv_top[c++];
+        }
+      }
+    }
+    return;
+  }
+#endif
+
+  // y periodic boundaries (serial or 1 rank).
+  for (int v = 0; v < kNumVars; ++v) {
+    for (int i = 0; i < nx_tot_; ++i) {
+      for (int g = 0; g < ng; ++g) {
+        at(u, v, i, g) = at(u, v, i, local_ny_ + g);
+        at(u, v, i, ng + local_ny_ + g) = at(u, v, i, ng + g);
+      }
+    }
+  }
+}
+
+void MHD2D::enforce_floors(std::vector<double>& u) const {
+  const int ng = params_.ng;
+  for (int j = ng; j < ng + local_ny_; ++j) {
+    for (int i = ng; i < ng + params_.nx; ++i) {
+      State s = load_state(u, i, j);
+      Primitive w = conserved_to_primitive(s);
+      s = primitive_to_conserved(w);
+      store_state(u, i, j, s);
+    }
+  }
+}
+
+void MHD2D::compute_rhs(const std::vector<double>& u,
+                        std::vector<double>& rhs,
+                        bool second_order) const {
+  std::fill(rhs.begin(), rhs.end(), 0.0);
+
+  const int ng = params_.ng;
+  const int nx = params_.nx;
+  const int ny = local_ny_;
+
+  std::vector<double> fx(static_cast<std::size_t>(kNumVars) * (nx + 1) * ny, 0.0);
+  std::vector<double> fy(static_cast<std::size_t>(kNumVars) * nx * (ny + 1), 0.0);
+
+  auto fx_idx = [nx, ny](int v, int iface, int jlocal) {
+    return (v * ny + jlocal) * (nx + 1) + iface;
+  };
+
+  auto fy_idx = [nx, ny](int v, int ilocal, int jface) {
+    return (v * (ny + 1) + jface) * nx + ilocal;
+  };
+
+  auto regularize = [this](State& s) {
+    Primitive w = conserved_to_primitive(s);
+    s = primitive_to_conserved(w);
+  };
+
+  for (int jlocal = 0; jlocal < ny; ++jlocal) {
+    const int j = ng + jlocal;
+    for (int iface = 0; iface <= nx; ++iface) {
+      const int i_right = ng + iface;
+      const int i_left = i_right - 1;
+
+      State left = load_state(u, i_left, j);
+      State right = load_state(u, i_right, j);
+
+      if (second_order) {
+        for (int v = 0; v < kNumVars; ++v) {
+          const double dl_l = at(u, v, i_left, j) - at(u, v, i_left - 1, j);
+          const double dr_l = at(u, v, i_left + 1, j) - at(u, v, i_left, j);
+          const double slope_l = minmod(dl_l, dr_l);
+
+          const double dl_r = at(u, v, i_right, j) - at(u, v, i_right - 1, j);
+          const double dr_r = at(u, v, i_right + 1, j) - at(u, v, i_right, j);
+          const double slope_r = minmod(dl_r, dr_r);
+
+          left[v] += 0.5 * slope_l;
+          right[v] -= 0.5 * slope_r;
+        }
+      }
+
+      regularize(left);
+      regularize(right);
+      const State f = riemann_flux(left, right, 0);
+      for (int v = 0; v < kNumVars; ++v) {
+        fx[fx_idx(v, iface, jlocal)] = f[v];
+      }
+    }
+  }
+
+  for (int jface = 0; jface <= ny; ++jface) {
+    const int j_top = ng + jface;
+    const int j_bottom = j_top - 1;
+
+    for (int ilocal = 0; ilocal < nx; ++ilocal) {
+      const int i = ng + ilocal;
+
+      State bottom = load_state(u, i, j_bottom);
+      State top = load_state(u, i, j_top);
+
+      if (second_order) {
+        for (int v = 0; v < kNumVars; ++v) {
+          const double dl_b = at(u, v, i, j_bottom) - at(u, v, i, j_bottom - 1);
+          const double dr_b = at(u, v, i, j_bottom + 1) - at(u, v, i, j_bottom);
+          const double slope_b = minmod(dl_b, dr_b);
+
+          const double dl_t = at(u, v, i, j_top) - at(u, v, i, j_top - 1);
+          const double dr_t = at(u, v, i, j_top + 1) - at(u, v, i, j_top);
+          const double slope_t = minmod(dl_t, dr_t);
+
+          bottom[v] += 0.5 * slope_b;
+          top[v] -= 0.5 * slope_t;
+        }
+      }
+
+      regularize(bottom);
+      regularize(top);
+      const State g = riemann_flux(bottom, top, 1);
+      for (int v = 0; v < kNumVars; ++v) {
+        fy[fy_idx(v, ilocal, jface)] = g[v];
+      }
+    }
+  }
+
+  for (int jlocal = 0; jlocal < ny; ++jlocal) {
+    const int j = ng + jlocal;
+    for (int ilocal = 0; ilocal < nx; ++ilocal) {
+      const int i = ng + ilocal;
+      for (int v = 0; v < kNumVars; ++v) {
+        const double dfx = (fx[fx_idx(v, ilocal + 1, jlocal)] - fx[fx_idx(v, ilocal, jlocal)]) / dx_;
+        const double dfy = (fy[fy_idx(v, ilocal, jlocal + 1)] - fy[fy_idx(v, ilocal, jlocal)]) / dy_;
+        at(rhs, v, i, j) = -(dfx + dfy);
+      }
+      at(rhs, kPsi, i, j) += -params_.glm_damping * at(u, kPsi, i, j);
+    }
+  }
+}
+
+void MHD2D::initialize_orszag_tang() {
+  const int ng = params_.ng;
+  constexpr double pi = 3.14159265358979323846;
+
+  for (int jlocal = 0; jlocal < local_ny_; ++jlocal) {
+    const int j = ng + jlocal;
+    const int jg = y_offset_ + jlocal;
+
+    for (int ilocal = 0; ilocal < params_.nx; ++ilocal) {
+      const int i = ng + ilocal;
+
+      const double x = params_.x_min + (static_cast<double>(ilocal) + 0.5) * dx_;
+      const double y = params_.y_min + (static_cast<double>(jg) + 0.5) * dy_;
+
+      Primitive w{};
+      w.rho = 25.0 / (36.0 * pi);
+      w.p = 5.0 / (12.0 * pi);
+      w.vx = -std::sin(y);
+      w.vy = std::sin(x);
+      w.vz = 0.0;
+      w.bx = -std::sin(y);
+      w.by = std::sin(2.0 * x);
+      w.bz = 0.0;
+      w.psi = 0.0;
+
+      const State s = primitive_to_conserved(w);
+      store_state(u_, i, j, s);
+    }
+  }
+
+  fill_boundaries(u_);
+}
+
+double MHD2D::compute_time_step() const {
+  if (params_.fixed_dt > 0.0) {
+    return params_.fixed_dt;
+  }
+
+  const int ng = params_.ng;
+  double local_max = 1.0e-12;
+
+  for (int j = ng; j < ng + local_ny_; ++j) {
+    for (int i = ng; i < ng + params_.nx; ++i) {
+      const State s = load_state(u_, i, j);
+      const double sx = signal_speed(s, 0);
+      const double sy = signal_speed(s, 1);
+      local_max = std::max(local_max, sx);
+      local_max = std::max(local_max, sy);
+    }
+  }
+
+  local_max = std::max(local_max, params_.glm_ch);
+
+  double global_max = local_max;
+#ifdef OT_USE_MPI
+  if (size_ > 1) {
+    MPI_Allreduce(&local_max, &global_max, 1, MPI_DOUBLE, MPI_MAX, comm_);
+  }
+#endif
+
+  const double dt = params_.cfl * std::min(dx_, dy_) / std::max(global_max, 1.0e-12);
+  return dt;
+}
+
+void MHD2D::advance(double dt) {
+  const int ng = params_.ng;
+
+  fill_boundaries(u_);
+
+  if (params_.reconstruction == ReconstructionType::FirstOrder) {
+    compute_rhs(u_, rhs_, false);
+
+    for (int j = ng; j < ng + local_ny_; ++j) {
+      for (int i = ng; i < ng + params_.nx; ++i) {
+        for (int v = 0; v < kNumVars; ++v) {
+          at(u_, v, i, j) += dt * at(rhs_, v, i, j);
+        }
+      }
+    }
+
+    enforce_floors(u_);
+    fill_boundaries(u_);
+    return;
+  }
+
+  compute_rhs(u_, rhs_, true);
+
+  stage_ = u_;
+  for (int j = ng; j < ng + local_ny_; ++j) {
+    for (int i = ng; i < ng + params_.nx; ++i) {
+      for (int v = 0; v < kNumVars; ++v) {
+        at(stage_, v, i, j) += dt * at(rhs_, v, i, j);
+      }
+    }
+  }
+
+  enforce_floors(stage_);
+  fill_boundaries(stage_);
+  compute_rhs(stage_, rhs_stage_, true);
+
+  for (int j = ng; j < ng + local_ny_; ++j) {
+    for (int i = ng; i < ng + params_.nx; ++i) {
+      for (int v = 0; v < kNumVars; ++v) {
+        const double un = at(u_, v, i, j);
+        const double u1 = at(stage_, v, i, j);
+        const double rhs1 = at(rhs_stage_, v, i, j);
+        at(u_, v, i, j) = 0.5 * (un + u1 + dt * rhs1);
+      }
+    }
+  }
+
+  enforce_floors(u_);
+  fill_boundaries(u_);
+}
+
+void MHD2D::extract_output(OutputFields& fields) const {
+  const std::size_t local_size = static_cast<std::size_t>(params_.nx) * local_ny_;
+
+  fields.rho.assign(local_size, 0.0);
+  fields.pressure.assign(local_size, 0.0);
+  fields.vx.assign(local_size, 0.0);
+  fields.vy.assign(local_size, 0.0);
+  fields.vz.assign(local_size, 0.0);
+  fields.bx.assign(local_size, 0.0);
+  fields.by.assign(local_size, 0.0);
+  fields.bz.assign(local_size, 0.0);
+  fields.speed.assign(local_size, 0.0);
+  fields.current_z.assign(local_size, 0.0);
+  if (params_.output_psi) {
+    fields.psi.assign(local_size, 0.0);
+  } else {
+    fields.psi.clear();
+  }
+  if (params_.output_m) {
+    fields.mx.assign(local_size, 0.0);
+    fields.my.assign(local_size, 0.0);
+    fields.mz.assign(local_size, 0.0);
+  } else {
+    fields.mx.clear();
+    fields.my.clear();
+    fields.mz.clear();
+  }
+  if (params_.output_E) {
+    fields.E.assign(local_size, 0.0);
+  } else {
+    fields.E.clear();
+  }
+
+  const int ng = params_.ng;
+
+  for (int jlocal = 0; jlocal < local_ny_; ++jlocal) {
+    const int j = ng + jlocal;
+
+    for (int ilocal = 0; ilocal < params_.nx; ++ilocal) {
+      const int i = ng + ilocal;
+      const std::size_t out = static_cast<std::size_t>(jlocal) * params_.nx + ilocal;
+
+      const State s = load_state(u_, i, j);
+      const Primitive w = conserved_to_primitive(s);
+
+      fields.rho[out] = w.rho;
+      fields.pressure[out] = w.p;
+      fields.vx[out] = w.vx;
+      fields.vy[out] = w.vy;
+      fields.vz[out] = w.vz;
+      fields.bx[out] = w.bx;
+      fields.by[out] = w.by;
+      fields.bz[out] = w.bz;
+      fields.speed[out] = std::sqrt(w.vx * w.vx + w.vy * w.vy + w.vz * w.vz);
+      if (params_.output_psi) {
+        fields.psi[out] = w.psi;
+      }
+      if (params_.output_m) {
+        fields.mx[out] = s[kMx];
+        fields.my[out] = s[kMy];
+        fields.mz[out] = s[kMz];
+      }
+      if (params_.output_E) {
+        fields.E[out] = s[kE];
+      }
+
+      const double dby_dx = (at(u_, kBy, i + 1, j) - at(u_, kBy, i - 1, j)) / (2.0 * dx_);
+      const double dbx_dy = (at(u_, kBx, i, j + 1) - at(u_, kBx, i, j - 1)) / (2.0 * dy_);
+      fields.current_z[out] = dby_dx - dbx_dy;
+    }
+  }
+}
+
+void MHD2D::compute_diagnostics(ScalarDiagnostics& diagnostics) const {
+  const int ng = params_.ng;
+  const std::size_t global_cells =
+      static_cast<std::size_t>(params_.nx) * static_cast<std::size_t>(params_.ny);
+
+  double sum_rho = 0.0;
+  double sum_kin = 0.0;
+  double sum_mag = 0.0;
+  double sum_int = 0.0;
+  double sum_tot = 0.0;
+  double sum_p = 0.0;
+  double sum_j2 = 0.0;
+  double sum_divb2 = 0.0;
+  double max_speed = 0.0;
+  double max_jabs = 0.0;
+  double max_divb_abs = 0.0;
+
+  for (int jlocal = 0; jlocal < local_ny_; ++jlocal) {
+    const int j = ng + jlocal;
+    for (int ilocal = 0; ilocal < params_.nx; ++ilocal) {
+      const int i = ng + ilocal;
+
+      const State s = load_state(u_, i, j);
+      const Primitive w = conserved_to_primitive(s);
+
+      const double v2 = w.vx * w.vx + w.vy * w.vy + w.vz * w.vz;
+      const double b2 = w.bx * w.bx + w.by * w.by + w.bz * w.bz;
+      const double speed = std::sqrt(v2);
+
+      sum_rho += w.rho;
+      sum_kin += 0.5 * w.rho * v2;
+      sum_mag += 0.5 * b2;
+      sum_int += w.p / (params_.gamma - 1.0);
+      sum_tot += s[kE];
+      sum_p += w.p;
+      max_speed = std::max(max_speed, speed);
+
+      const double dby_dx = (at(u_, kBy, i + 1, j) - at(u_, kBy, i - 1, j)) / (2.0 * dx_);
+      const double dbx_dy = (at(u_, kBx, i, j + 1) - at(u_, kBx, i, j - 1)) / (2.0 * dy_);
+      const double current_z = dby_dx - dbx_dy;
+      const double jabs = std::abs(current_z);
+      sum_j2 += current_z * current_z;
+      max_jabs = std::max(max_jabs, jabs);
+
+      const double dbx_dx = (at(u_, kBx, i + 1, j) - at(u_, kBx, i - 1, j)) / (2.0 * dx_);
+      const double dby_dy = (at(u_, kBy, i, j + 1) - at(u_, kBy, i, j - 1)) / (2.0 * dy_);
+      const double divb = dbx_dx + dby_dy;
+      const double divb_abs = std::abs(divb);
+      sum_divb2 += divb * divb;
+      max_divb_abs = std::max(max_divb_abs, divb_abs);
+    }
+  }
+
+  std::array<double, 8> sums_local = {
+      sum_rho, sum_kin, sum_mag, sum_int, sum_tot, sum_p, sum_j2, sum_divb2};
+  std::array<double, 3> max_local = {max_speed, max_jabs, max_divb_abs};
+
+  std::array<double, 8> sums_global = sums_local;
+  std::array<double, 3> max_global = max_local;
+
+#ifdef OT_USE_MPI
+  if (size_ > 1) {
+    MPI_Allreduce(sums_local.data(), sums_global.data(),
+                  static_cast<int>(sums_local.size()), MPI_DOUBLE, MPI_SUM, comm_);
+    MPI_Allreduce(max_local.data(), max_global.data(),
+                  static_cast<int>(max_local.size()), MPI_DOUBLE, MPI_MAX, comm_);
+  }
+#endif
+
+  const double cell_area = dx_ * dy_;
+  const double inv_cells = 1.0 / static_cast<double>(global_cells);
+
+  diagnostics.mass = sums_global[0] * cell_area;
+  diagnostics.kinetic_energy = sums_global[1] * cell_area;
+  diagnostics.magnetic_energy = sums_global[2] * cell_area;
+  diagnostics.internal_energy = sums_global[3] * cell_area;
+  diagnostics.total_energy = sums_global[4] * cell_area;
+  diagnostics.mean_pressure = sums_global[5] * inv_cells;
+  diagnostics.max_speed = max_global[0];
+  diagnostics.current_abs_max = max_global[1];
+  diagnostics.current_rms = std::sqrt(sums_global[6] * inv_cells);
+  diagnostics.divb_abs_max = max_global[2];
+  diagnostics.divb_l2 = std::sqrt(sums_global[7] * inv_cells);
+}
+
+std::string flux_to_string(FluxType flux) {
+  return (flux == FluxType::Rusanov) ? "rusanov" : "hll";
+}
+
+std::string reconstruction_to_string(ReconstructionType recon) {
+  return (recon == ReconstructionType::FirstOrder) ? "first_order" : "muscl";
+}
+
+bool parse_solver_name(const std::string& name, FluxType& flux, ReconstructionType& recon) {
+  std::string s = name;
+  std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+
+  if (s == "rusanov" || s == "rusanov1" || s == "llf" || s == "first_order_rusanov") {
+    flux = FluxType::Rusanov;
+    recon = ReconstructionType::FirstOrder;
+    return true;
+  }
+
+  if (s == "hll" || s == "hll1" || s == "first_order_hll") {
+    flux = FluxType::HLL;
+    recon = ReconstructionType::FirstOrder;
+    return true;
+  }
+
+  if (s == "muscl" || s == "muscl_hll" || s == "muscl-hll" || s == "rk2_hll") {
+    flux = FluxType::HLL;
+    recon = ReconstructionType::MUSCL;
+    return true;
+  }
+
+  if (s == "muscl_rusanov" || s == "muscl-rusanov" || s == "rk2_rusanov") {
+    flux = FluxType::Rusanov;
+    recon = ReconstructionType::MUSCL;
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace ot

--- a/examples/mhd_orszag_tang/src/mhd2d.hpp
+++ b/examples/mhd_orszag_tang/src/mhd2d.hpp
@@ -1,0 +1,191 @@
+#pragma once
+
+#include <array>
+#include <limits>
+#include <string>
+#include <vector>
+
+#ifdef OT_USE_MPI
+#include <mpi.h>
+#endif
+
+namespace ot {
+
+constexpr int kNumVars = 9;
+
+constexpr int kRho = 0;
+constexpr int kMx = 1;
+constexpr int kMy = 2;
+constexpr int kMz = 3;
+constexpr int kBx = 4;
+constexpr int kBy = 5;
+constexpr int kBz = 6;
+constexpr int kE = 7;
+constexpr int kPsi = 8;
+
+enum class FluxType {
+  Rusanov,
+  HLL,
+};
+
+enum class ReconstructionType {
+  FirstOrder,
+  MUSCL,
+};
+
+struct SimulationParams {
+  int nx = 256;
+  int ny = 256;
+  int ng = 2;
+  int max_steps = 250000;
+  int log_every_steps = 50;
+
+  double x_min = 0.0;
+  double x_max = 6.2831853071795864769;  // 2*pi
+  double y_min = 0.0;
+  double y_max = 6.2831853071795864769;  // 2*pi
+
+  double gamma = 5.0 / 3.0;
+  double cfl = 0.35;
+  double tfinal = 1.0;
+
+  double rho_floor = 1.0e-8;
+  double p_floor = 1.0e-8;
+
+  double glm_ch = 1.0;
+  double glm_damping = 0.1;
+
+  FluxType flux = FluxType::HLL;
+  ReconstructionType reconstruction = ReconstructionType::MUSCL;
+
+  std::string output_file = "output/output.bp";
+  std::string adios_engine = "BP5";
+  std::string prepend_var_names;
+  double fixed_dt = 0.0;
+  bool output_psi = false;
+  bool output_m = false;
+  bool output_E = false;
+  int output_every_steps = 20;
+  double output_every_time = 0.0;
+  bool save_initial = true;
+};
+
+struct OutputFields {
+  std::vector<double> rho;
+  std::vector<double> pressure;
+  std::vector<double> vx;
+  std::vector<double> vy;
+  std::vector<double> vz;
+  std::vector<double> bx;
+  std::vector<double> by;
+  std::vector<double> bz;
+  std::vector<double> speed;
+  std::vector<double> current_z;
+  std::vector<double> psi;
+  std::vector<double> mx;
+  std::vector<double> my;
+  std::vector<double> mz;
+  std::vector<double> E;
+};
+
+struct ScalarDiagnostics {
+  double mass = 0.0;
+  double kinetic_energy = 0.0;
+  double magnetic_energy = 0.0;
+  double internal_energy = 0.0;
+  double total_energy = 0.0;
+  double mean_pressure = 0.0;
+  double max_speed = 0.0;
+  double current_abs_max = 0.0;
+  double current_rms = 0.0;
+  double divb_abs_max = 0.0;
+  double divb_l2 = 0.0;
+};
+
+class MHD2D {
+ public:
+#ifdef OT_USE_MPI
+  MHD2D(const SimulationParams& params, MPI_Comm comm);
+#else
+  explicit MHD2D(const SimulationParams& params);
+#endif
+
+  void initialize_orszag_tang();
+  double compute_time_step() const;
+  void advance(double dt);
+  void extract_output(OutputFields& fields) const;
+  void compute_diagnostics(ScalarDiagnostics& diagnostics) const;
+
+  int global_nx() const { return params_.nx; }
+  int global_ny() const { return params_.ny; }
+  int local_ny() const { return local_ny_; }
+  int y_offset() const { return y_offset_; }
+  int rank() const { return rank_; }
+  int size() const { return size_; }
+
+ private:
+  using State = std::array<double, kNumVars>;
+
+  struct Primitive {
+    double rho;
+    double vx;
+    double vy;
+    double vz;
+    double bx;
+    double by;
+    double bz;
+    double p;
+    double psi;
+  };
+
+  int idx(int v, int i, int j) const;
+  double at(const std::vector<double>& u, int v, int i, int j) const;
+  double& at(std::vector<double>& u, int v, int i, int j) const;
+
+  State load_state(const std::vector<double>& u, int i, int j) const;
+  void store_state(std::vector<double>& u, int i, int j, const State& s) const;
+
+  Primitive conserved_to_primitive(const State& s) const;
+  State primitive_to_conserved(const Primitive& w) const;
+
+  State flux(const State& s, int dir) const;
+  State riemann_flux(const State& left, const State& right, int dir) const;
+  double fast_magnetosonic(const Primitive& w, int dir) const;
+  double signal_speed(const State& s, int dir) const;
+
+  static double minmod(double a, double b);
+
+  void fill_boundaries(std::vector<double>& u) const;
+  void enforce_floors(std::vector<double>& u) const;
+  void compute_rhs(const std::vector<double>& u, std::vector<double>& rhs, bool second_order) const;
+
+ private:
+  SimulationParams params_;
+
+#ifdef OT_USE_MPI
+  MPI_Comm comm_;
+#endif
+
+  int rank_ = 0;
+  int size_ = 1;
+
+  int local_ny_ = 0;
+  int y_offset_ = 0;
+
+  int nx_tot_ = 0;
+  int ny_tot_ = 0;
+
+  double dx_ = 0.0;
+  double dy_ = 0.0;
+
+  std::vector<double> u_;
+  std::vector<double> rhs_;
+  std::vector<double> stage_;
+  std::vector<double> rhs_stage_;
+};
+
+std::string flux_to_string(FluxType flux);
+std::string reconstruction_to_string(ReconstructionType recon);
+bool parse_solver_name(const std::string& name, FluxType& flux, ReconstructionType& recon);
+
+}  // namespace ot


### PR DESCRIPTION
This PR adds a complete Orszag-Tang MHD example to the repository, including a buildable C++/ADIOS2 solver, a small ensemble runner, and a minimal set of ensemble configs. The example supports running single cases or ensembles that write ADIOS output and input parameter files into per-run output directories.

The ensemble runner is designed to be simple and explicit. The example configs include a basic run set and a resolution sweep, and the solver no longer creates an empty images/ directory in each run output. The README documents build steps, ensemble usage, and a short TL;DR command for the common resolution-sweep workflow.