### PR TITLE
Control visualization image addition verbosity

### DIFF
--- a/hpc_campaign/manager.py
+++ b/hpc_campaign/manager.py
@@ -193,6 +193,7 @@ class Manager:  # pylint: disable=too-many-public-methods
         name: str | None = None,
         store: bool = False,
         thumbnail: list[int] | tuple[int, int] | None = None,
+        verbose: int | None = None,
     ):
         file_path = str(file_path)
         thumb_value = None
@@ -200,7 +201,13 @@ class Manager:  # pylint: disable=too-many-public-methods
             thumb_value = [int(thumbnail[0]), int(thumbnail[1])]
         cmd_args = self._build_command_args(
             "image",
-            {"file": file_path, "name": name, "store": store, "thumbnail": thumb_value},
+            {
+                "file": file_path,
+                "name": name,
+                "store": store,
+                "thumbnail": thumb_value,
+                "verbose": self.args.verbose if verbose is None else int(verbose),
+            },
         )
         if not self.connected:
             self.open(create=True, truncate=False)
@@ -213,6 +220,7 @@ class Manager:  # pylint: disable=too-many-public-methods
         name: str | None = None,
         thumbnail: list[int] | tuple[int, int] | None = None,
         replica_name: str | None = None,
+        verbose: int | None = None,
     ):
         thumb_value = None
         if thumbnail is not None:
@@ -225,6 +233,7 @@ class Manager:  # pylint: disable=too-many-public-methods
                 "name": name,
                 "thumbnail": thumb_value,
                 "replica_name": replica_name,
+                "verbose": self.args.verbose if verbose is None else int(verbose),
             },
         )
         if not self.connected:
@@ -365,6 +374,7 @@ class Manager:  # pylint: disable=too-many-public-methods
         streamline_by=None,
         x_axis: str | None = None,
         y_axis=None,
+        verbose: int | None = None,
     ) -> int:
         image_inputs = self._normalize_visualization_images(images)
         if not image_inputs:
@@ -398,6 +408,7 @@ class Manager:  # pylint: disable=too-many-public-methods
         if not 0 <= int(thumbnail_image) < len(image_inputs):
             raise ValueError("thumbnail_image index is out of range")
 
+        image_verbose = int(self.args.verbose if verbose is None else verbose)
         for idx, image_input in enumerate(image_inputs):
             logical_name = logical_image_names[idx]
             if self._is_path_like_image(image_input):
@@ -406,6 +417,7 @@ class Manager:  # pylint: disable=too-many-public-methods
                     name=logical_name,
                     store=store,
                     thumbnail=thumbnail,
+                    verbose=image_verbose,
                 )
             else:
                 image_bytes, resolved_format = self._coerce_image_input(image_input, image_format)
@@ -415,6 +427,7 @@ class Manager:  # pylint: disable=too-many-public-methods
                     name=logical_name,
                     thumbnail=thumbnail,
                     replica_name=f"generated/{Path(logical_name).name}",
+                    verbose=image_verbose,
                 )
 
         return self.visualization_sequence(

--- a/hpc_campaign/manager_funcs.py
+++ b/hpc_campaign/manager_funcs.py
@@ -141,9 +141,14 @@ def encrypt_buffer(args: argparse.Namespace, buf: bytes):
         box = nacl.secret.SecretBox(args.encryption_key)
         nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
         e = box.encrypt(buf, nonce)
-        print("Encoded buffer size: ", len(e))
+        if is_verbose(args):
+            print("Encoded buffer size: ", len(e))
         return e
     return buf
+
+
+def is_verbose(args: argparse.Namespace) -> bool:
+    return int(getattr(args, "verbose", 0) or 0) > 0
 
 
 def lastrowid_or_zero(cur_ds: sqlite3.Cursor) -> int:
@@ -260,12 +265,14 @@ def add_replica_to_archive(
     mt: float,
     size: int,
     indent: str = "",
+    verbose: bool = True,
 ) -> int:
-    print(f"{indent}Add replica {dataset} to archive")
-    print(
-        f"{indent}add_replica_to_archive(host={host_id}, dir={dir_id}, archive={archive_id}, "
-        f"key={key_id}, name={dataset} dsid={datasetid}, time={mt}, size={size})"
-    )
+    if verbose:
+        print(f"{indent}Add replica {dataset} to archive")
+        print(
+            f"{indent}add_replica_to_archive(host={host_id}, dir={dir_id}, archive={archive_id}, "
+            f"key={key_id}, name={dataset} dsid={datasetid}, time={mt}, size={size})"
+        )
     cur_ds = sql_execute(
         cur,
         "insert into replica (datasetid, hostid, dirid, archiveid, name, modtime, deltime, keyid, size) "
@@ -277,7 +284,8 @@ def add_replica_to_archive(
         (datasetid, host_id, dir_id, archive_id, dataset, mt, 0, key_id, size),
     )
     row_id = cur_ds.fetchone()[0]
-    print(f"{indent}  Replica rowid = {row_id}")
+    if verbose:
+        print(f"{indent}  Replica rowid = {row_id}")
     return row_id
 
 
@@ -288,8 +296,10 @@ def add_dataset_to_archive(
     fileformat: str,
     mt: float = 0.0,
     indent: str = "",
+    verbose: bool = True,
 ) -> int:
-    print(f"{indent}Add dataset {name} to archive")
+    if verbose:
+        print(f"{indent}Add dataset {name} to archive")
     cur_ds = sql_execute(
         cur,
         "insert into dataset (name, uuid, modtime, deltime, fileformat, tsid, tsorder) "
@@ -308,8 +318,10 @@ def add_resolution_to_archive(
     y: int,
     cur: sqlite3.Cursor,
     indent: str = "",
+    verbose: bool = True,
 ) -> int:
-    print(f"{indent}Add resolution {x} {y} for replica {rep_id} to archive")
+    if verbose:
+        print(f"{indent}Add resolution {x} {y} for replica {rep_id} to archive")
     cur_ds = sql_execute(
         cur,
         "insert into resolution (replicaid, x, y) "
@@ -707,29 +719,45 @@ def process_image(
     dataset = args.file
     if args.name is not None:
         dataset = args.name
+    verbose = is_verbose(args)
 
     statres = stat(args.file)
     mt = statres.st_mtime_ns
     filesize = statres.st_size
     unique_id = uuid.uuid3(uuid.NAMESPACE_URL, location + "/" + args.file).hex
-    print(f"Process image {location}/{args.file}")
+    if verbose:
+        print(f"Process image {location}/{args.file}")
 
     img = Image.open(args.file)
     imgres = img.size
 
-    ds_id = add_dataset_to_archive(dataset, cur, unique_id, "IMAGE", mt, indent="  ")
-    rep_id = add_replica_to_archive(host_id, dir_id, 0, key_id, args.file, cur, ds_id, mt, filesize, indent="  ")
-    add_resolution_to_archive(rep_id, imgres[0], imgres[1], cur, indent="  ")
+    ds_id = add_dataset_to_archive(dataset, cur, unique_id, "IMAGE", mt, indent="  ", verbose=verbose)
+    rep_id = add_replica_to_archive(
+        host_id,
+        dir_id,
+        0,
+        key_id,
+        args.file,
+        cur,
+        ds_id,
+        mt,
+        filesize,
+        indent="  ",
+        verbose=verbose,
+    )
+    add_resolution_to_archive(rep_id, imgres[0], imgres[1], cur, indent="  ", verbose=verbose)
 
     if args.store or args.thumbnail is not None:
         imgsuffix = Path(args.file).suffix
         if args.store:
-            print("Storing the image in the archive")
+            if verbose:
+                print("Storing the image in the archive")
             resname = f"{imgres[0]}x{imgres[1]}{imgsuffix}"
             add_file_to_archive(args, args.file, cur, rep_id, mt, resname, compress=False, indent="  ")
 
         else:
-            print(f"  Make thumbnail image with resolution {args.thumbnail}")
+            if verbose:
+                print(f"  Make thumbnail image with resolution {args.thumbnail}")
             img.thumbnail(args.thumbnail)
             imgres = img.size
             resname = f"{imgres[0]}x{imgres[1]}{imgsuffix}"
@@ -750,6 +778,7 @@ def process_image(
                 now,
                 filesize,
                 indent="  ",
+                verbose=verbose,
             )
             add_file_to_archive(
                 args,
@@ -761,7 +790,7 @@ def process_image(
                 compress=False,
                 indent="  ",
             )
-            add_resolution_to_archive(thumb_rep_id, imgres[0], imgres[1], cur, indent="  ")
+            add_resolution_to_archive(thumb_rep_id, imgres[0], imgres[1], cur, indent="  ", verbose=verbose)
             remove(thumbfilename)
 
 
@@ -792,21 +821,36 @@ def process_image_data(
 
     mt = time_ns()
     filesize = len(image_bytes)
-    print(f"Process in-memory image {dataset}")
+    verbose = is_verbose(args)
+    if verbose:
+        print(f"Process in-memory image {dataset}")
 
     img = Image.open(BytesIO(image_bytes))
     img.load()
     imgres = img.size
 
-    ds_id = add_dataset_to_archive(dataset, cur, unique_id, "IMAGE", mt, indent="  ")
-    rep_id = add_replica_to_archive(host_id, dir_id, 0, key_id, replica_name, cur, ds_id, mt, filesize, indent="  ")
-    add_resolution_to_archive(rep_id, imgres[0], imgres[1], cur, indent="  ")
+    ds_id = add_dataset_to_archive(dataset, cur, unique_id, "IMAGE", mt, indent="  ", verbose=verbose)
+    rep_id = add_replica_to_archive(
+        host_id,
+        dir_id,
+        0,
+        key_id,
+        replica_name,
+        cur,
+        ds_id,
+        mt,
+        filesize,
+        indent="  ",
+        verbose=verbose,
+    )
+    add_resolution_to_archive(rep_id, imgres[0], imgres[1], cur, indent="  ", verbose=verbose)
 
     resname = f"{imgres[0]}x{imgres[1]}{suffix}"
     add_file_to_archive(args, "", cur, rep_id, mt, resname, compress=False, content=image_bytes, indent="  ")
 
     if args.thumbnail is not None:
-        print(f"  Make thumbnail image with resolution {args.thumbnail}")
+        if verbose:
+            print(f"  Make thumbnail image with resolution {args.thumbnail}")
         thumb_img = img.copy()
         thumb_img.thumbnail(args.thumbnail)
         thumb_res = thumb_img.size
@@ -825,6 +869,7 @@ def process_image_data(
             thumb_now,
             len(thumb_bytes),
             indent="  ",
+            verbose=verbose,
         )
         thumb_resname = f"{thumb_res[0]}x{thumb_res[1]}{suffix}"
         add_file_to_archive(
@@ -838,16 +883,17 @@ def process_image_data(
             content=thumb_bytes,
             indent="  ",
         )
-        add_resolution_to_archive(thumb_rep_id, thumb_res[0], thumb_res[1], cur, indent="  ")
+        add_resolution_to_archive(thumb_rep_id, thumb_res[0], thumb_res[1], cur, indent="  ", verbose=verbose)
 
 
 def add_image_data(args: argparse.Namespace, cur: sqlite3.Cursor, con: sqlite3.Connection):
     long_host_name, short_host_name = get_host_name(args)
+    verbose = is_verbose(args)
 
-    host_id = add_host_name(long_host_name, short_host_name, cur)
-    key_id = add_key_id(args.encryption_key_id, cur)
+    host_id = add_host_name(long_host_name, short_host_name, cur, verbose=verbose)
+    key_id = add_key_id(args.encryption_key_id, cur, verbose=verbose)
     rootdir = getcwd()
-    dir_id = add_directory(host_id, rootdir, cur)
+    dir_id = add_directory(host_id, rootdir, cur, verbose=verbose)
     sql_commit(con)
 
     process_image_data(args, cur, host_id, dir_id, key_id, long_host_name + rootdir, rootdir)
@@ -1105,12 +1151,14 @@ def add_host_name(
     cur: sqlite3.Cursor,
     default_protocol: str = "",
     indent: str = "",
+    verbose: bool = True,
 ) -> int:
     res = sql_execute(cur, 'select rowid from host where hostname = "' + short_host_name + '"')
     row = res.fetchone()
     if row is not None:
         host_id = row[0]
-        print(f"{indent}Found host {short_host_name} in database, rowid = {host_id}")
+        if verbose:
+            print(f"{indent}Found host {short_host_name} in database, rowid = {host_id}")
     else:
         cur_host = sql_execute(
             cur,
@@ -1118,13 +1166,15 @@ def add_host_name(
             (short_host_name, long_host_name, CURRENT_TIME, 0, default_protocol),
         )
         host_id = lastrowid_or_zero(cur_host)
-        print(
-            f"{indent}Inserted host {short_host_name} into database, rowid = {host_id}, longhostname = {long_host_name}"
-        )
+        if verbose:
+            print(
+                f"{indent}Inserted host {short_host_name} into database, rowid = {host_id}, "
+                f"longhostname = {long_host_name}"
+            )
     return host_id
 
 
-def add_directory(host_id: int, path: str, cur: sqlite3.Cursor, indent: str = "") -> int:
+def add_directory(host_id: int, path: str, cur: sqlite3.Cursor, indent: str = "", verbose: bool = True) -> int:
     res = sql_execute(
         cur,
         "select rowid from directory where hostid = " + str(host_id) + ' and name = "' + path + '"',
@@ -1132,7 +1182,8 @@ def add_directory(host_id: int, path: str, cur: sqlite3.Cursor, indent: str = ""
     row = res.fetchone()
     if row is not None:
         dir_id = row[0]
-        print(f"{indent}Found directory {path} with host_id {host_id} in database, rowid = {dir_id}")
+        if verbose:
+            print(f"{indent}Found directory {path} with host_id {host_id} in database, rowid = {dir_id}")
     else:
         cur_directory = sql_execute(
             cur,
@@ -1140,24 +1191,27 @@ def add_directory(host_id: int, path: str, cur: sqlite3.Cursor, indent: str = ""
             (host_id, path, CURRENT_TIME, 0),
         )
         dir_id = lastrowid_or_zero(cur_directory)
-        print(f"{indent}Inserted directory {path} into database, rowid = {dir_id}")
+        if verbose:
+            print(f"{indent}Inserted directory {path} into database, rowid = {dir_id}")
     return dir_id
 
 
-def add_key_id(key_id: str, cur: sqlite3.Cursor) -> int:
+def add_key_id(key_id: str, cur: sqlite3.Cursor, verbose: bool = True) -> int:
     key_row_id: int = 0  # an invalid row id
     if key_id:
         res = sql_execute(cur, 'select rowid from key where keyid = "' + key_id + '"')
         row = res.fetchone()
         if row is not None:
             key_row_id = int(row[0])
-            print(f"Found key {key_id} in database, rowid = {key_row_id}")
+            if verbose:
+                print(f"Found key {key_id} in database, rowid = {key_row_id}")
         else:
             cmd = f'insert into key values ("{(key_id)}")'
             cur_key = sql_execute(cur, cmd)
             # cur_key = sql_execute(cur,"insert into key values (?)", (key_id))
             key_row_id = lastrowid_or_zero(cur_key)
-            print(f"Inserted key {key_id} into database, rowid = {key_row_id}")
+            if verbose:
+                print(f"Inserted key {key_id} into database, rowid = {key_row_id}")
     return key_row_id
 
 
@@ -1390,16 +1444,17 @@ def add_archival_storage(
 
 def update(args: argparse.Namespace, cur: sqlite3.Cursor, con: sqlite3.Connection):
     long_host_name, short_host_name = get_host_name(args)
+    verbose = is_verbose(args) if args.command == "image" else True
 
-    host_id = add_host_name(long_host_name, short_host_name, cur)
-    key_id = add_key_id(args.encryption_key_id, cur)
+    host_id = add_host_name(long_host_name, short_host_name, cur, verbose=verbose)
+    key_id = add_key_id(args.encryption_key_id, cur, verbose=verbose)
 
     if args.remote_data and args.s3_bucket is not None:
         rootdir = args.s3_bucket
     else:
         rootdir = getcwd()
 
-    dir_id = add_directory(host_id, rootdir, cur)
+    dir_id = add_directory(host_id, rootdir, cur, verbose=verbose)
     sql_commit(con)
 
     if args.command == "data":

--- a/tests/test_visualization_sequence.py
+++ b/tests/test_visualization_sequence.py
@@ -173,6 +173,43 @@ def test_visualization_single_file_convenience_api(tmp_path: Path):
     manager.close()
 
 
+def test_visualization_convenience_api_respects_verbose(tmp_path: Path, capsys):
+    archive_name = "visualization_verbose.aca"
+    image_path_a = tmp_path / "frame_a.png"
+    image_path_b = tmp_path / "frame_b.png"
+    image_path_c = tmp_path / "frame_c.png"
+    Image.new("RGB", (12, 10), color="purple").save(image_path_a)
+    Image.new("RGB", (12, 10), color="green").save(image_path_b)
+    Image.new("RGB", (12, 10), color="orange").save(image_path_c)
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path), verbose=0)
+    manager.open(create=True, truncate=True)
+    manager.data(str(data_dir / "onearray.h5"), name="output")
+
+    capsys.readouterr()
+    manager.visualization(
+        images=[image_path_a, image_path_b],
+        vis_type="heatmap",
+        source_dataset="output",
+        variables=[{"name": "temp", "role": "primary"}],
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+    manager.visualization(
+        images=image_path_c,
+        vis_type="heatmap",
+        source_dataset="output",
+        name="temp_verbose",
+        variables=[{"name": "temp", "role": "primary"}],
+        verbose=1,
+    )
+    captured = capsys.readouterr()
+    assert "Process image" in captured.out
+
+    manager.close()
+
+
 def test_visualization_sequence_file_list_convenience_api(tmp_path: Path):
     archive_name = "visualization_convenience_sequence.aca"
     first_dir = tmp_path / "a"


### PR DESCRIPTION
Adds verbosity control for visualization image addition.

Manager.visualization() now honors the manager’s verbose setting and also accepts a per-call verbose override. Image addition output is quiet by default for large visualization sequences, while verbose=1 still prints the existing diagnostic messages. A test covers both quiet and verbose behavior.