### PR TITLE
Require stored in-memory visualization images

### DIFF
--- a/docs/source/usage_api.rst
+++ b/docs/source/usage_api.rst
@@ -133,6 +133,12 @@ set and variable uses. This is useful in notebooks where a user reads a
 variable, performs analysis, creates figures, and wants to save those figures
 back into the campaign.
 
+File-backed image inputs follow the same storage rule as ``image``: by default
+the campaign records a reference to the image file, and ``store=True`` embeds
+the image bytes in the archive. In-memory image inputs such as PNG/JPEG bytes,
+PIL Images, and matplotlib Figures have no external file path, so they require
+``store=True``.
+
 Example usage:
 
 .. code-block:: python
@@ -148,6 +154,7 @@ Example usage:
       kind="heatmap",
       color_by="rho",
       steps=[0, 1, 2],
+      store=True,
       replace=True,
   )
 
@@ -395,4 +402,3 @@ Comparing the campaign archive size to the data it points to can be done by the 
 
   $ du -sh /path/to/adios-campaign-store/demoproject/test_campaign_001 info.aca
   127K     /path/to/adios-campaign-store/demoproject/test_campaign_001 info.aca
-

--- a/hpc_campaign/manager.py
+++ b/hpc_campaign/manager.py
@@ -220,8 +220,12 @@ class Manager:  # pylint: disable=too-many-public-methods
         name: str | None = None,
         thumbnail: list[int] | tuple[int, int] | None = None,
         replica_name: str | None = None,
+        store: bool = True,
         verbose: int | None = None,
     ):
+        if not store:
+            raise ValueError("image_data requires store=True because in-memory images have no external replica path")
+
         thumb_value = None
         if thumbnail is not None:
             thumb_value = [int(thumbnail[0]), int(thumbnail[1])]
@@ -233,6 +237,7 @@ class Manager:  # pylint: disable=too-many-public-methods
                 "name": name,
                 "thumbnail": thumb_value,
                 "replica_name": replica_name,
+                "store": store,
                 "verbose": self.args.verbose if verbose is None else int(verbose),
             },
         )
@@ -427,6 +432,7 @@ class Manager:  # pylint: disable=too-many-public-methods
                     name=logical_name,
                     thumbnail=thumbnail,
                     replica_name=f"generated/{Path(logical_name).name}",
+                    store=store,
                     verbose=image_verbose,
                 )
 

--- a/hpc_campaign/manager_funcs.py
+++ b/hpc_campaign/manager_funcs.py
@@ -825,6 +825,8 @@ def process_image_data(
     image_format = str(args.image_format or "").strip()
     if not image_format:
         raise ValueError("image_data requires image_format")
+    if not getattr(args, "store", True):
+        raise ValueError("image_data requires store=True because in-memory images have no external replica path")
 
     suffix = "." + image_format.lower().lstrip(".")
     if args.name is not None:

--- a/tests/test_visualization_sequence.py
+++ b/tests/test_visualization_sequence.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from PIL import Image
 
 from hpc_campaign.info import format_image_associations, format_info
@@ -281,6 +282,7 @@ def test_visualization_in_memory_image_convenience_api(tmp_path: Path):
         source_dataset="output",
         variables=[{"name": "temp", "role": "primary"}],
         thumbnail=(4, 4),
+        store=True,
     )
 
     assert visid > 0
@@ -292,6 +294,32 @@ def test_visualization_in_memory_image_convenience_api(tmp_path: Path):
     )
     assert len(image_dataset.replicas) == 2
     assert any(replica.flags.embedded for replica in image_dataset.replicas.values())
+
+    manager.close()
+
+
+def test_in_memory_image_inputs_require_store_true(tmp_path: Path):
+    archive_name = "visualization_memory_store_false.aca"
+    image = Image.new("RGB", (10, 10), color="orange")
+    png_path = tmp_path / "memory.png"
+    image.save(png_path)
+    png_bytes = png_path.read_bytes()
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(data_dir / "onearray.h5"), name="output")
+
+    with pytest.raises(ValueError, match="image_data requires store=True"):
+        manager.image_data(png_bytes, image_format="PNG", name="memory/image.png", store=False)
+
+    with pytest.raises(ValueError, match="image_data requires store=True"):
+        manager.visualization(
+            images=png_bytes,
+            vis_type="heatmap",
+            source_dataset="output",
+            variables=[{"name": "temp", "role": "primary"}],
+            store=False,
+        )
 
     manager.close()
 


### PR DESCRIPTION
Adds consistent store behavior for in-memory visualization images.

File-backed image inputs can still use store=False to register by reference, matching ADIOS-style behavior. In-memory image inputs now require store=True, because there is no external file path to reference. The change adds explicit errors for image_data(..., store=False) and visualization(images=<bytes>, store=False), updates the visualization API docs, and adds tests for the new behavior.