### PR TITLE
Add scalar field visualization API support

### DIFF
--- a/docs/source/usage_cli.rst
+++ b/docs/source/usage_cli.rst
@@ -144,7 +144,70 @@ Additional options for images include:
 * `\-\-store, -s` stores the image file directly in the campaign archive instead of just a reference.
 * `\-\-thumbnail <X> <Y>` stores a resized image with an X-by-Y resolution as a thumbnail, while referring to the original.
 
-**6. info**
+**6. scalar-field**
+
+Add a rank-2 scalar field to the archive. Raw scalar field files require an
+explicit shape and dtype. NumPy ``.npy`` files infer shape and dtype from the
+array unless these are supplied to validate or convert the input.
+
+Example usage:
+
+.. code-block:: bash
+
+  hpc_campaign manager demoproject/test_campaign_001 scalar-field pressure.000000.raw \
+    --name output/visualizations/pressure_scalar_field/scalar.000000.raw \
+    --shape 128 128 \
+    --dtype float32
+
+  hpc_campaign manager demoproject/test_campaign_001 scalar-field pressure.000000.npy \
+    --name output/visualizations/pressure_scalar_field/scalar.000000.raw
+
+
+Additional options for scalar fields include:
+
+* ``--layout`` scalar field memory layout. Currently only ``row-major`` is supported.
+* ``--encoding`` scalar field payload encoding. Currently only ``raw`` is supported.
+* ``--compression`` scalar field payload compression. Currently only ``none`` is supported.
+* ``--value-encoding`` scalar value representation. Currently only ``direct`` is supported.
+* ``--metadata-json <FILE>`` adds extra scalar field metadata from a JSON object.
+
+**7. visualization-sequence**
+
+Add or replace a visualization sequence from a JSON manifest. This is the
+recommended CLI path for scalar-field sequences because variables and items are
+structured data.
+
+Example manifest:
+
+.. code-block:: json
+
+  {
+    "name": "output/visualizations/pressure_scalar_field",
+    "vis_type": "heatmap",
+    "source_dataset": "output",
+    "variables": [{"name": "pressure", "role": "color-by"}],
+    "items": [
+      {
+        "type": "SCALAR_FIELD",
+        "name": "output/visualizations/pressure_scalar_field/scalar.000000.raw"
+      },
+      {
+        "type": "SCALAR_FIELD",
+        "name": "output/visualizations/pressure_scalar_field/scalar.000001.raw"
+      }
+    ],
+    "metadata": {"colormap": "viridis"},
+    "replace": true
+  }
+
+Example usage:
+
+.. code-block:: bash
+
+  hpc_campaign manager demoproject/test_campaign_001 visualization-sequence pressure_sequence.json
+
+
+**8. info**
 
 Prints the content and metadata of a campaign archive file.
 Example usage:
@@ -156,7 +219,7 @@ Example usage:
 The optional options allow listing replicas, entries that have been deleted and checksums. A complete list of options can be found in the help menu (`-h` option).
 
 
-**7. text**
+**9. text**
 
 Add one or more text files to the archive. If requested, text files are stored within the archive. In that case, zlib is used to compress the text file.
 
@@ -175,7 +238,7 @@ Additional options for text include:
 * `\-\-name, -n <NAME>` representation name for one text file in the campaign hierarchy
 * `\-\-store, -s` stores the text file directly in the campaign archive instead of just a reference.
 
-**8. time-series**
+**10. time-series**
 
 Organizes a sequence of datasets into a single named time-series. Subsequent calls with the same name will add datasets to the list, unless `\-\-replace` is used.
 
@@ -213,7 +276,7 @@ Additional options for text include:
 * `\-\-remove`  delete the time-series definition (but not the datasets)
 
 
-**9. upgrade**
+**11. upgrade**
 
 An ADIOS2 release will only read the latest ACA version and throw errors if an older ACA files is opened. The `upgrade` sub-command will modify the old ACA to jump to the next version. It may be called multiple times to get to the current version. This is an in-place conversion. If an error occurs during conversion, all changes are cancelled, leaving the original file intact. 
 
@@ -270,5 +333,4 @@ Comparing the campaign archive size to the data it points to can be done by the 
 
   $ du -sh /path/to/adios-campaign-store/demoproject/test_campaign_001 info.aca
   127K     /path/to/adios-campaign-store/demoproject/test_campaign_001 info.aca
-
 

--- a/hpc_campaign/info.py
+++ b/hpc_campaign/info.py
@@ -112,6 +112,7 @@ class DatasetInfo:
     del_time: int
     file_format: str
     replicas: dict[int, ReplicaInfo] = field(default_factory=dict)
+    metadata: dict | None = None
 
 
 @dataclass
@@ -175,10 +176,10 @@ class InfoResult:
 # fmt: off
 SELECT_DATA_CMD = """
 SELECT
-    d.rowid             AS ds_id, 
+    d.rowid             AS ds_id,
     d.name              AS ds_name,
     d.uuid              AS ds_uuid,
-    d.modtime           AS ds_modtime, 
+    d.modtime           AS ds_modtime,
     d.deltime           AS ds_deltime,
     d.fileformat        AS ds_fileformat,
     d.tsid              AS ds_tsid,
@@ -299,6 +300,54 @@ LEFT JOIN repfiles AS rf
 LEFT JOIN file AS f
     ON f.fileid = rf.fileid
 WHERE d.fileformat = 'TEXT'
+ORDER BY d.rowid, r.rowid, f.fileid;
+"""
+
+SELECT_SCALAR_FIELDS_CMD = """
+SELECT
+    d.rowid             AS ds_id,
+    d.name              AS ds_name,
+    d.uuid              AS ds_uuid,
+    d.modtime           AS ds_modtime,
+    d.deltime           AS ds_deltime,
+    d.fileformat        AS ds_fileformat,
+    d.tsid              AS ds_tsid,
+
+    r.rowid             AS rep_id,
+    r.hostid            AS hostid,
+    r.dirid             AS dirid,
+    r.archiveid         AS archiveid,
+    r.name              AS rep_name,
+    r.modtime           AS rep_modtime,
+    r.deltime           AS rep_deltime,
+    r.keyid             AS keyid,
+    r.size              AS rep_size,
+
+    rf.fileid           AS repfile_id,
+
+    f.name              AS file_name,
+    f.compression       AS compression,
+    f.lenorig           AS lenorig,
+    f.lencompressed     AS lencompressed,
+    f.modtime           AS file_modtime,
+    f.checksum          AS checksum,
+
+    res.x               AS res_x,
+    res.y               AS res_y,
+    sf.metadata         AS scalar_metadata
+
+FROM dataset AS d
+JOIN replica AS r
+    ON r.datasetid = d.rowid
+LEFT JOIN repfiles AS rf
+    ON rf.replicaid = r.rowid
+LEFT JOIN file AS f
+    ON f.fileid = rf.fileid
+LEFT JOIN resolution AS res
+    ON res.replicaid = r.rowid
+LEFT JOIN scalar_field AS sf
+    ON sf.datasetid = d.rowid
+WHERE d.fileformat = 'SCALAR_FIELD'
 ORDER BY d.rowid, r.rowid, f.fileid;
 """
 
@@ -441,6 +490,40 @@ def info_images(  # pylint: disable=too-many-locals
             continue
 
 
+def info_scalar_fields(  # pylint: disable=too-many-locals
+    args: argparse.Namespace,
+    info_data: InfoResult,
+    cur: sqlite3.Cursor,
+    dirs_archived: dict[int, bool],
+):
+    res_tables = sql_execute(cur, "select name from sqlite_master where type = 'table' and name = 'scalar_field'")
+    if res_tables.fetchone() is None:
+        return
+
+    res = sql_execute(cur, SELECT_SCALAR_FIELDS_CMD)
+    for row in res:
+        resolution = None
+        if row["res_x"] is not None and row["res_y"] is not None:
+            resolution = ResolutionInfo(int(row["res_x"]), int(row["res_y"]))
+        dataset_info = info_row(
+            args,
+            info_data,
+            row,
+            accuracy=False,
+            embedded=(row["repfile_id"] is not None),
+            resolution=resolution,
+            dirs_archived=dirs_archived,
+        )
+        if dataset_info is None:
+            continue
+        if row["scalar_metadata"]:
+            try:
+                metadata = json.loads(row["scalar_metadata"])
+                dataset_info.metadata = metadata if isinstance(metadata, dict) else None
+            except (json.JSONDecodeError, TypeError):
+                dataset_info.metadata = None
+
+
 def info_texts(  # pylint: disable=too-many-locals
     args: argparse.Namespace,
     info_data: InfoResult,
@@ -578,6 +661,7 @@ def collect_info(  # pylint: disable=too-many-locals,too-many-statements
         info_datas(args, info_datasets, cur, dirs_archived)
         info_texts(args, info_datasets, cur, dirs_archived)
         info_images(args, info_datasets, cur, dirs_archived)
+        info_scalar_fields(args, info_datasets, cur, dirs_archived)
 
     res_tables = sql_execute(
         cur,
@@ -685,7 +769,7 @@ def format_info_dataset_lines(  # pylint: disable=too-many-locals
         else:
             replica_line += "  "
 
-        if dataset_info.file_format == "IMAGE" and replica_info.resolution is not None:
+        if dataset_info.file_format in {"IMAGE", "SCALAR_FIELD"} and replica_info.resolution is not None:
             res = replica_info.resolution
             resolution_text = f" {res.x} x {res.y}".rjust(14)
         else:
@@ -811,7 +895,9 @@ def _format_visualization_metadata(metadata: str | None) -> str | None:
 def format_image_associations(info_data: InfoResult) -> str:
     lines = []
     sequences = list(info_data.visualization_sequences.values())
-    image_datasets = [dataset for dataset in _collect_all_datasets(info_data) if dataset.file_format == "IMAGE"]
+    image_datasets = [
+        dataset for dataset in _collect_all_datasets(info_data) if dataset.file_format in {"IMAGE", "SCALAR_FIELD"}
+    ]
 
     for dataset in image_datasets:
         lines.append(f"{dataset.name}: {dataset.file_format}")

--- a/hpc_campaign/manager.py
+++ b/hpc_campaign/manager.py
@@ -8,6 +8,8 @@
 # pylint: disable=too-many-positional-arguments
 
 import argparse
+import json
+import math
 import sqlite3
 import sys
 from io import BytesIO
@@ -15,6 +17,7 @@ from os.path import exists
 from pathlib import Path
 from time import time_ns
 
+import numpy as np
 from PIL import Image as PILImage
 
 from .info import InfoResult, collect_info, print_image_associations, print_info
@@ -23,6 +26,7 @@ from .manager_args import ArgParser
 from .manager_funcs import (
     add_archival_storage,
     add_image_data,
+    add_scalar_field_data,
     add_time_series,
     add_visualization_sequence,
     archive_dataset,
@@ -244,6 +248,42 @@ class Manager:  # pylint: disable=too-many-public-methods
         if not self.connected:
             self.open(create=True, truncate=False)
         add_image_data(cmd_args, self.cur, self.con)
+
+    def scalar_field_data(
+        self,
+        data,
+        name: str | None = None,
+        dtype: str | None = None,
+        shape: list[int] | tuple[int, int] | None = None,
+        metadata=None,
+        layout: str = "row-major",
+        compression: str = "none",
+        encoding: str = "raw",
+        replica_name: str | None = None,
+        verbose: int | None = None,
+    ):
+        payload, scalar_metadata = self._coerce_scalar_field_input(
+            data=data,
+            dtype=dtype,
+            shape=shape,
+            metadata=metadata,
+            layout=layout,
+            compression=compression,
+            encoding=encoding,
+        )
+        cmd_args = self._build_command_args(
+            "scalar_field_data",
+            {
+                "scalar_field_data": payload,
+                "scalar_field_metadata": scalar_metadata,
+                "name": name,
+                "replica_name": replica_name,
+                "verbose": self.args.verbose if verbose is None else int(verbose),
+            },
+        )
+        if not self.connected:
+            self.open(create=True, truncate=False)
+        add_scalar_field_data(cmd_args, self.cur, self.con)
 
     def delete_uuid(self, uuid: str):
         if not self.connected:
@@ -504,6 +544,139 @@ class Manager:  # pylint: disable=too-many-public-methods
             return buf.getvalue(), resolved_format
         raise TypeError(f"Unsupported visualization image input type: {type(image)!r}")
 
+    def _validate_scalar_field_storage_options(self, layout: str, compression: str, encoding: str):
+        layout_value = str(layout or "").strip().lower()
+        if layout_value != "row-major":
+            raise ValueError("Only row-major scalar field layout is supported currently")
+
+        compression_value = str(compression or "").strip().lower()
+        if compression_value != "none":
+            raise ValueError("Only compression='none' is supported for scalar fields currently")
+
+        encoding_value = str(encoding or "").strip().lower()
+        if encoding_value != "raw":
+            raise ValueError("Only encoding='raw' is supported for scalar fields currently")
+
+    def _normalize_scalar_field_shape(self, shape: list[int] | tuple[int, int] | None) -> tuple[int, ...]:
+        shape_tuple = tuple(int(dim) for dim in shape) if shape is not None else ()
+        if shape_tuple and len(shape_tuple) != 2:
+            raise ValueError("shape=[height, width] must contain exactly two dimensions")
+        return shape_tuple
+
+    def _normalize_scalar_field_input_data(self, data):
+        if isinstance(data, memoryview):
+            return data.tobytes()
+        if isinstance(data, bytearray):
+            return bytes(data)
+        return data
+
+    def _scalar_field_storage_dtype(self, dtype) -> np.dtype:
+        storage_dtype = np.dtype(dtype).newbyteorder("<")
+        if storage_dtype.kind not in {"f", "u", "i"}:
+            raise ValueError(f"Unsupported scalar field dtype: {storage_dtype.name}")
+        return storage_dtype
+
+    def _coerce_scalar_field_bytes(
+        self,
+        data: bytes,
+        dtype: str | None,
+        shape_tuple: tuple[int, ...],
+    ) -> tuple[bytes, np.ndarray, np.dtype]:
+        if dtype is None:
+            raise ValueError("dtype is required when scalar field data is bytes")
+        if len(shape_tuple) != 2:
+            raise ValueError("shape=[height, width] is required when scalar field data is bytes")
+
+        storage_dtype = self._scalar_field_storage_dtype(dtype)
+        expected = math.prod(shape_tuple) * storage_dtype.itemsize
+        if len(data) != expected:
+            raise ValueError(f"Scalar field byte payload has {len(data)} bytes; expected {expected}")
+
+        arr = np.frombuffer(data, dtype=storage_dtype).reshape(shape_tuple)
+        return data, arr, storage_dtype
+
+    def _coerce_scalar_field_array(
+        self,
+        data,
+        dtype: str | None,
+        shape_tuple: tuple[int, ...],
+    ) -> tuple[bytes, np.ndarray, np.dtype, tuple[int, ...]]:
+        arr = np.asarray(data)
+        if arr.ndim != 2:
+            raise ValueError("scalar_field_data requires a rank-2 array or explicit shape=[height, width]")
+        if len(shape_tuple) == 2 and shape_tuple != tuple(int(dim) for dim in arr.shape):
+            raise ValueError(f"shape={list(shape_tuple)} does not match scalar field array shape={list(arr.shape)}")
+
+        array_shape = tuple(int(dim) for dim in arr.shape)
+        storage_dtype = self._scalar_field_storage_dtype(dtype if dtype is not None else arr.dtype)
+        arr = np.ascontiguousarray(arr.astype(storage_dtype, copy=False))
+        return arr.tobytes(order="C"), arr, storage_dtype, array_shape
+
+    def _build_scalar_field_metadata(
+        self,
+        metadata,
+        shape_tuple: tuple[int, ...],
+        storage_dtype: np.dtype,
+        arr: np.ndarray,
+    ) -> dict:
+        if shape_tuple[0] <= 0 or shape_tuple[1] <= 0:
+            raise ValueError("Scalar field shape must be [height, width] with positive dimensions")
+
+        scalar_metadata = dict(metadata or {})
+        value_encoding = str(scalar_metadata.get("value_encoding", "direct") or "direct").strip().lower()
+        if value_encoding != "direct":
+            raise ValueError("Only value_encoding='direct' is supported for scalar fields currently")
+        scalar_metadata.update(
+            {
+                "format_version": 1,
+                "kind": "scalarField",
+                "rank": 2,
+                "shape": [int(shape_tuple[0]), int(shape_tuple[1])],
+                "dtype": storage_dtype.name,
+                "byte_order": "little",
+                "layout": "row-major",
+                "encoding": "raw",
+                "compression": "none",
+                "value_encoding": "direct",
+            }
+        )
+
+        if "min" not in scalar_metadata or "max" not in scalar_metadata:
+            if storage_dtype.kind == "f":
+                finite = arr[np.isfinite(arr)]
+            else:
+                finite = arr.reshape(-1)
+            if finite.size:
+                scalar_metadata.setdefault("min", float(np.min(finite)))
+                scalar_metadata.setdefault("max", float(np.max(finite)))
+
+        return scalar_metadata
+
+    def _coerce_scalar_field_input(
+        self,
+        data,
+        dtype: str | None,
+        shape: list[int] | tuple[int, int] | None,
+        metadata,
+        layout: str,
+        compression: str,
+        encoding: str,
+    ) -> tuple[bytes, dict]:
+        self._validate_scalar_field_storage_options(layout, compression, encoding)
+        shape_tuple = self._normalize_scalar_field_shape(shape)
+        data = self._normalize_scalar_field_input_data(data)
+
+        if isinstance(data, bytes):
+            payload, arr, storage_dtype = self._coerce_scalar_field_bytes(data, dtype, shape_tuple)
+        else:
+            payload, arr, storage_dtype, shape_tuple = self._coerce_scalar_field_array(data, dtype, shape_tuple)
+
+        if len(shape_tuple) != 2:
+            raise ValueError("Scalar field shape must be [height, width] with positive dimensions")
+
+        scalar_metadata = self._build_scalar_field_metadata(metadata, shape_tuple, storage_dtype, arr)
+        return payload, scalar_metadata
+
     def _normalize_visualization_variable_specs(self, variables, source_dataset: str | None):
         if isinstance(variables, (str, dict, tuple)):
             variable_list = [variables]
@@ -686,6 +859,31 @@ class Manager:  # pylint: disable=too-many-public-methods
         return ".png"
 
 
+def _load_json_object(path: str, label: str) -> dict:
+    with open(path, encoding="utf-8") as json_file:
+        data = json.load(json_file)
+    if not isinstance(data, dict):
+        raise ValueError(f"{label} must contain a JSON object")
+    return data
+
+
+def _load_scalar_field_cli_input(args: argparse.Namespace) -> tuple[bytes | np.ndarray, dict]:
+    input_path = Path(args.file)
+    metadata = _load_json_object(args.metadata_json, "scalar field metadata") if args.metadata_json else {}
+    if args.value_encoding is not None:
+        metadata["value_encoding"] = args.value_encoding
+
+    if input_path.suffix.lower() == ".npy":
+        return np.load(input_path, allow_pickle=False), metadata
+    return input_path.read_bytes(), metadata
+
+
+def _require_manifest_fields(manifest: dict, required_fields: tuple[str, ...]) -> None:
+    missing = [field for field in required_fields if field not in manifest]
+    if missing:
+        raise ValueError(f"visualization sequence manifest is missing required field(s): {', '.join(missing)}")
+
+
 # pylint:disable = too-many-statements
 def main(args=None, prog=None):
     parser = ArgParser(args=args, prog=prog)
@@ -704,7 +902,14 @@ def main(args=None, prog=None):
         # print("--------------------------")
         n_cmd += 1
         create_allowed = True
-        if parser.args.command in ("info", "add-archival-storage", "archived-replica", "time-series", "upgrade"):
+        if parser.args.command in (
+            "info",
+            "visualization-sequence",
+            "add-archival-storage",
+            "archived-replica",
+            "time-series",
+            "upgrade",
+        ):
             create_allowed = False
         if n_cmd == 1:
             try:
@@ -727,6 +932,33 @@ def main(args=None, prog=None):
             manager.text(parser.args.files, parser.args.name, parser.args.store)
         elif parser.args.command == "image":
             manager.image(parser.args.file, parser.args.name, parser.args.store, parser.args.thumbnail)
+        elif parser.args.command == "scalar-field":
+            scalar_data, scalar_metadata = _load_scalar_field_cli_input(parser.args)
+            manager.scalar_field_data(
+                scalar_data,
+                name=parser.args.name,
+                dtype=parser.args.dtype,
+                shape=parser.args.shape,
+                metadata=scalar_metadata,
+                layout=parser.args.layout,
+                compression=parser.args.compression,
+                encoding=parser.args.encoding,
+                replica_name=parser.args.replica_name,
+            )
+        elif parser.args.command == "visualization-sequence":
+            manifest = _load_json_object(parser.args.manifest, "visualization sequence manifest")
+            _require_manifest_fields(manifest, ("name", "vis_type", "variables", "items"))
+            manager.visualization_sequence(
+                name=manifest["name"],
+                vis_type=manifest["vis_type"],
+                variables=manifest["variables"],
+                items=manifest["items"],
+                source_dataset=manifest.get("source_dataset"),
+                thumbnail_name=manifest.get("thumbnail_name"),
+                thumbnail_uuid=manifest.get("thumbnail_uuid"),
+                metadata=manifest.get("metadata"),
+                replace=bool(manifest.get("replace", False) or parser.args.replace),
+            )
         elif parser.args.command == "delete":
             if parser.args.uuid is not None:
                 for uid in parser.args.uuid:

--- a/hpc_campaign/manager_args.py
+++ b/hpc_campaign/manager_args.py
@@ -10,6 +10,8 @@ __accepted_commands__ = [
     "data",
     "text",
     "image",
+    "scalar-field",
+    "visualization-sequence",
     "add-archival-storage",
     "archived-replica",
     "time-series",
@@ -238,6 +240,88 @@ The archive can '--store' directly the image file, or store a --thumbnail with X
             help="Store a resized image with resolution of x-by-y and refer to original",
         )
 
+        # parser for the "scalar-field" command
+        parser_scalar_field = argparse.ArgumentParser(
+            prog=f"{prog} <archive> scalar-field",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description="""
+Add a rank-2 scalar field to the archive. NumPy .npy inputs infer shape and
+dtype automatically unless overridden. Raw byte inputs require --shape and
+--dtype so that the payload can be interpreted unambiguously.
+""",
+        )
+        parsers["scalar-field"] = parser_scalar_field
+        parser_scalar_field.add_argument("file", help="raw scalar field file or NumPy .npy file")
+        parser_scalar_field.add_argument(
+            "--name",
+            "-n",
+            default=None,
+            help="Representation name in the campaign hierarchy",
+        )
+        parser_scalar_field.add_argument(
+            "--shape",
+            nargs=2,
+            default=None,
+            type=int,
+            metavar=("height", "width"),
+            help="Scalar field shape. Required for raw files; validates .npy array shape when supplied.",
+        )
+        parser_scalar_field.add_argument(
+            "--dtype",
+            default=None,
+            help="NumPy dtype for the scalar field. Required for raw files; converts .npy arrays when supplied.",
+        )
+        parser_scalar_field.add_argument(
+            "--layout",
+            default="row-major",
+            help="Scalar field memory layout. Currently only row-major is supported.",
+        )
+        parser_scalar_field.add_argument(
+            "--encoding",
+            default="raw",
+            help="Scalar field payload encoding. Currently only raw is supported.",
+        )
+        parser_scalar_field.add_argument(
+            "--compression",
+            default="none",
+            help="Scalar field payload compression. Currently only none is supported.",
+        )
+        parser_scalar_field.add_argument(
+            "--value-encoding",
+            default=None,
+            help="Scalar value representation. Currently only direct is supported.",
+        )
+        parser_scalar_field.add_argument(
+            "--metadata-json",
+            default=None,
+            metavar="file",
+            help="Optional JSON object with extra scalar field metadata.",
+        )
+        parser_scalar_field.add_argument(
+            "--replica-name",
+            default=None,
+            help="Optional replica name to store in the archive.",
+        )
+
+        # parser for the "visualization-sequence" command
+        parser_vis_sequence = argparse.ArgumentParser(
+            prog=f"{prog} <archive> visualization-sequence",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description="""
+Add or replace a visualization sequence from a JSON manifest. The manifest
+contains the same fields as the Python Manager.visualization_sequence() API:
+name, vis_type, variables, items, and optional source_dataset, thumbnail_name,
+thumbnail_uuid, metadata, and replace.
+""",
+        )
+        parsers["visualization-sequence"] = parser_vis_sequence
+        parser_vis_sequence.add_argument("manifest", help="JSON visualization sequence manifest")
+        parser_vis_sequence.add_argument(
+            "--replace",
+            help="Replace an existing visualization sequence with the same name",
+            action="store_true",
+        )
+
         # parser for the "add-archival-storage" command
         parser_addarchive = argparse.ArgumentParser(
             prog=f"{prog} <archive>  add-archival-storage",
@@ -352,10 +436,25 @@ One may need to run upgrade several times to reach the newest format.
             del args.show_checksum
             del args.list_replicas
             del args.list_files
+            del args.images
         elif command == "delete":
             del args.name
             del args.uuid
             del args.replica
+        elif command == "scalar-field":
+            del args.file
+            del args.name
+            del args.shape
+            del args.dtype
+            del args.layout
+            del args.encoding
+            del args.compression
+            del args.value_encoding
+            del args.metadata_json
+            del args.replica_name
+        elif command == "visualization-sequence":
+            del args.manifest
+            del args.replace
         elif command == "add-archival-storage":
             del args.host
             del args.system

--- a/hpc_campaign/manager_funcs.py
+++ b/hpc_campaign/manager_funcs.py
@@ -42,6 +42,23 @@ from .utils import (
     sql_execute,
 )
 
+SCALAR_FIELD_FORMAT = "SCALAR_FIELD"
+SCALAR_FIELD_KIND = "scalarField"
+SCALAR_FIELD_SEQUENCE_COMPATIBILITY_KEYS = (
+    "rank",
+    "shape",
+    "dtype",
+    "byte_order",
+    "layout",
+    "encoding",
+    "compression",
+    "value_encoding",
+)
+SUPPORTED_VISUALIZATION_ITEM_FORMATS = {
+    "IMAGE": "IMAGE",
+    SCALAR_FIELD_FORMAT: SCALAR_FIELD_FORMAT,
+}
+
 
 def find_host_def(args: argparse.Namespace, hostname: str) -> dict | str | None:
     """
@@ -351,6 +368,84 @@ def add_resolution_to_archive(
     return row_id
 
 
+def ensure_scalar_field_tables(cur: sqlite3.Cursor, con: sqlite3.Connection):
+    sql_execute(
+        cur,
+        "create table if not exists scalar_field" + "(datasetid INT PRIMARY KEY, metadata TEXT)",
+    )
+    sql_commit(con)
+
+
+def add_scalar_field_metadata_to_archive(
+    datasetid: int,
+    metadata: dict,
+    cur: sqlite3.Cursor,
+    indent: str = "",
+    verbose: bool = True,
+) -> int:
+    if verbose:
+        print(f"{indent}Add scalar field metadata for dataset {datasetid} to archive")
+    cur_ds = sql_execute(
+        cur,
+        "insert into scalar_field (datasetid, metadata) values (?, ?) "
+        "on conflict (datasetid) do update set metadata = excluded.metadata returning rowid",
+        (datasetid, json.dumps(metadata, sort_keys=True)),
+    )
+    row_id = cur_ds.fetchone()[0]
+    return row_id
+
+
+def _scalar_field_metadata_for_dataset(cur: sqlite3.Cursor, datasetid: int, dataset_name: str) -> dict:
+    res = sql_execute(cur, "select metadata from scalar_field where datasetid = ?", (datasetid,))
+    row = res.fetchone()
+    if row is None or not row[0]:
+        raise ValueError(f"SCALAR_FIELD dataset is missing scalar metadata: {dataset_name}")
+    try:
+        metadata = json.loads(row[0])
+    except Exception as exc:
+        raise ValueError(f"SCALAR_FIELD dataset has invalid scalar metadata: {dataset_name}") from exc
+    if not isinstance(metadata, dict):
+        raise ValueError(f"SCALAR_FIELD dataset metadata must be a JSON object: {dataset_name}")
+    return metadata
+
+
+def _scalar_field_sequence_signature(metadata: dict, dataset_name: str) -> tuple:
+    try:
+        shape = metadata.get("shape", [])
+        if not isinstance(shape, list) or len(shape) != 2:
+            raise ValueError
+        rank = int(metadata.get("rank", len(shape)))
+        shape_tuple = (int(shape[0]), int(shape[1]))
+        dtype = str(metadata.get("dtype", "") or "").strip()
+        byte_order = str(metadata.get("byte_order", "") or "").strip().lower()
+        layout = str(metadata.get("layout", "") or "").strip().lower()
+        encoding = str(metadata.get("encoding", "") or "").strip().lower()
+        compression = str(metadata.get("compression", "") or "").strip().lower()
+        value_encoding = str(metadata.get("value_encoding", "") or "").strip().lower()
+    except Exception as exc:
+        raise ValueError(f"SCALAR_FIELD dataset has invalid shape/rank metadata: {dataset_name}") from exc
+
+    normalized = {
+        "rank": rank,
+        "shape": shape_tuple,
+        "dtype": dtype,
+        "byte_order": byte_order,
+        "layout": layout,
+        "encoding": encoding,
+        "compression": compression,
+        "value_encoding": value_encoding,
+    }
+    missing = [key for key, value in normalized.items() if value in {"", ()}]
+    if missing:
+        raise ValueError(f"SCALAR_FIELD dataset metadata is missing {', '.join(missing)}: {dataset_name}")
+    if rank != 2:
+        raise ValueError(f"SCALAR_FIELD visualization items must be rank 2: {dataset_name}")
+    if shape_tuple[0] <= 0 or shape_tuple[1] <= 0:
+        raise ValueError(f"SCALAR_FIELD visualization item shape dimensions must be positive: {dataset_name}")
+
+    return tuple(normalized[key] for key in SCALAR_FIELD_SEQUENCE_COMPATIBILITY_KEYS)
+
+
 def ensure_visualization_tables(cur: sqlite3.Cursor, con: sqlite3.Connection):
     sql_execute(
         cur,
@@ -476,8 +571,9 @@ def _normalize_visualization_items(items) -> list[dict[str, str | None]]:
         else:
             raise ValueError(f"Unsupported visualization item spec: {item!r}")
 
-        if item_type != "IMAGE":
-            raise ValueError(f"Unsupported visualization item type: {item_type}. Only IMAGE is supported currently")
+        if item_type not in SUPPORTED_VISUALIZATION_ITEM_FORMATS:
+            supported = ", ".join(sorted(SUPPORTED_VISUALIZATION_ITEM_FORMATS))
+            raise ValueError(f"Unsupported visualization item type: {item_type}. Supported types: {supported}")
         if not item_uuid and not item_name:
             raise ValueError(f"Visualization item requires either name or uuid: {item!r}")
         normalized.append(
@@ -510,6 +606,9 @@ def add_visualization_sequence(  # pylint: disable=too-many-statements
     default_source_dataset = str(getattr(args, "source_dataset", "") or "").strip()
     variable_specs = _normalize_visualization_variable_specs(args.variables, default_source_dataset)
     item_specs = _normalize_visualization_items(args.items)
+    item_types = {str(item_spec["type"]) for item_spec in item_specs}
+    if len(item_types) > 1:
+        raise ValueError("Visualization sequence items must all have the same type; mixed item types are not supported")
 
     source_dataset_ids: dict[str, int] = {}
     for variable_spec in variable_specs:
@@ -532,15 +631,34 @@ def add_visualization_sequence(  # pylint: disable=too-many-statements
             raise ValueError(f"thumbnail_name must refer to an IMAGE dataset, not {thumb_fileformat}")
 
     resolved_items: list[dict[str, str | None]] = []
+    scalar_field_signature = None
+    scalar_field_signature_name = ""
     for item_spec in item_specs:
         item_uuid = item_spec["uuid"]
         item_name = item_spec["name"]
         if item_uuid:
-            _item_id, _resolved_name, item_fileformat = _resolve_live_dataset_by_uuid(cur, str(item_uuid))
+            item_id, resolved_name, item_fileformat = _resolve_live_dataset_by_uuid(cur, str(item_uuid))
         else:
-            _item_id, item_uuid, item_fileformat = _resolve_live_dataset(cur, str(item_name))
-        if item_fileformat != "IMAGE":
-            raise ValueError(f"Visualization item must refer to an IMAGE dataset, not {item_fileformat}")
+            item_id, item_uuid, item_fileformat = _resolve_live_dataset(cur, str(item_name))
+            resolved_name = str(item_name)
+        expected_format = SUPPORTED_VISUALIZATION_ITEM_FORMATS[str(item_spec["type"])]
+        if item_fileformat != expected_format:
+            raise ValueError(
+                f"Visualization item type {item_spec['type']} must refer to a {expected_format} dataset, "
+                f"not {item_fileformat}"
+            )
+        if expected_format == SCALAR_FIELD_FORMAT:
+            scalar_metadata = _scalar_field_metadata_for_dataset(cur, item_id, resolved_name)
+            signature = _scalar_field_sequence_signature(scalar_metadata, resolved_name)
+            if scalar_field_signature is None:
+                scalar_field_signature = signature
+                scalar_field_signature_name = resolved_name
+            elif signature != scalar_field_signature:
+                raise ValueError(
+                    "All SCALAR_FIELD items in a visualization sequence must have compatible metadata "
+                    f"(rank, shape, dtype, byte order, layout, encoding, compression, value encoding). "
+                    f"First item: {scalar_field_signature_name}; mismatched item: {resolved_name}"
+                )
         resolved_items.append(
             {
                 "type": str(item_spec["type"]),
@@ -906,6 +1024,76 @@ def process_image_data(
         add_resolution_to_archive(thumb_rep_id, thumb_res[0], thumb_res[1], cur, indent="  ", verbose=verbose)
 
 
+def process_scalar_field_data(
+    args: argparse.Namespace,
+    cur: sqlite3.Cursor,
+    host_id: int,
+    dir_id: int,
+    key_id: int,
+    dirpath: str,
+    location: str,
+):
+    payload = bytes(args.scalar_field_data)
+    metadata = dict(getattr(args, "scalar_field_metadata", {}) or {})
+    if not payload:
+        raise ValueError("scalar_field_data requires a non-empty payload")
+
+    if metadata.get("kind") != SCALAR_FIELD_KIND:
+        raise ValueError(f"scalar_field_data metadata.kind must be {SCALAR_FIELD_KIND!r}")
+    if str(metadata.get("encoding", "") or "").lower() != "raw":
+        raise ValueError("Only raw scalar field encoding is supported currently")
+    if str(metadata.get("compression", "") or "").lower() != "none":
+        raise ValueError("Only uncompressed scalar field payloads are supported currently")
+
+    shape = metadata.get("shape", [])
+    if not isinstance(shape, list) or len(shape) != 2:
+        raise ValueError("scalar_field_data metadata.shape must be [height, width]")
+    height = int(shape[0])
+    width = int(shape[1])
+    if height <= 0 or width <= 0:
+        raise ValueError("scalar_field_data shape dimensions must be positive")
+
+    dtype = str(metadata.get("dtype", "") or "").strip()
+    if not dtype:
+        raise ValueError("scalar_field_data metadata.dtype is required")
+
+    if args.name is not None:
+        dataset = args.name
+        unique_id = uuid.uuid3(uuid.NAMESPACE_URL, location + "/" + dataset).hex
+    else:
+        checksum = sha1(payload + json.dumps(metadata, sort_keys=True).encode("utf-8")).hexdigest()
+        unique_id = uuid.uuid5(uuid.NAMESPACE_OID, checksum).hex
+        dataset = f"memory-scalar-fields/scalar-{unique_id[:12]}.raw"
+
+    replica_name = getattr(args, "replica_name", "") or join("memory-scalar-fields", f"{unique_id}.raw")
+
+    mt = time_ns()
+    verbose = is_verbose(args)
+    if verbose:
+        print(f"Process in-memory scalar field {dataset}")
+
+    ds_id = add_dataset_to_archive(dataset, cur, unique_id, SCALAR_FIELD_FORMAT, mt, indent="  ", verbose=verbose)
+    rep_id = add_replica_to_archive(
+        host_id,
+        dir_id,
+        0,
+        key_id,
+        replica_name,
+        cur,
+        ds_id,
+        mt,
+        len(payload),
+        indent="  ",
+        verbose=verbose,
+    )
+    add_resolution_to_archive(rep_id, width, height, cur, indent="  ", verbose=verbose)
+    add_scalar_field_metadata_to_archive(ds_id, metadata, cur, indent="  ", verbose=verbose)
+
+    safe_dtype = re.sub(r"[^A-Za-z0-9_.-]+", "_", dtype)
+    resname = f"{width}x{height}.{safe_dtype}.raw"
+    add_file_to_archive(args, "", cur, rep_id, mt, resname, compress=False, content=payload, indent="  ")
+
+
 def add_image_data(args: argparse.Namespace, cur: sqlite3.Cursor, con: sqlite3.Connection):
     long_host_name, short_host_name = get_host_name(args)
     verbose = is_verbose(args)
@@ -917,6 +1105,21 @@ def add_image_data(args: argparse.Namespace, cur: sqlite3.Cursor, con: sqlite3.C
     sql_commit(con)
 
     process_image_data(args, cur, host_id, dir_id, key_id, long_host_name + rootdir, rootdir)
+    sql_commit(con)
+
+
+def add_scalar_field_data(args: argparse.Namespace, cur: sqlite3.Cursor, con: sqlite3.Connection):
+    ensure_scalar_field_tables(cur, con)
+    long_host_name, short_host_name = get_host_name(args)
+    verbose = is_verbose(args)
+
+    host_id = add_host_name(long_host_name, short_host_name, cur, verbose=verbose)
+    key_id = add_key_id(args.encryption_key_id, cur, verbose=verbose)
+    rootdir = getcwd()
+    dir_id = add_directory(host_id, rootdir, cur, verbose=verbose)
+    sql_commit(con)
+
+    process_scalar_field_data(args, cur, host_id, dir_id, key_id, long_host_name + rootdir, rootdir)
     sql_commit(con)
 
 
@@ -1548,6 +1751,7 @@ def create_tables(campaign_file_name: str, con: sqlite3.Connection):
         "create table archive" + "(dirid INT, tarname TEXT,system TEXT, notes BLOB, PRIMARY KEY (dirid, tarname))",
     )
     ensure_visualization_tables(cur, con)
+    ensure_scalar_field_tables(cur, con)
     sql_execute(
         cur,
         "create table archiveidx"

--- a/hpc_campaign/types.py
+++ b/hpc_campaign/types.py
@@ -12,6 +12,7 @@ class DatasetType(IntEnum):
     HDF5 = 2
     IMAGE = 3
     TEXT = 4
+    SCALAR_FIELD = 5
 
 
 ADIOS_AvailableVariables: TypeAlias = dict[str, dict[str, str]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1740,4 +1740,4 @@ markers = {main = "python_version == \"3.10\""}
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "4f4fd11bdfb3fc6e1cd77ec1f78c3dee22a4264f4e5a7df3164f95a437fbff5e"
+content-hash = "9bb1b34c3fdd66f27dfe00c9e72d47e2757659b07d03db273e5e81d0442e24ec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "adios2 (>=2.12.0.1001)",
     "redis >= 5",
     "h5py >= 3.10",
+    "numpy >= 1.22",
     "pillow >= 12.1.1"
 ]
 

--- a/tests/test_visualization_sequence.py
+++ b/tests/test_visualization_sequence.py
@@ -1,10 +1,13 @@
+import json
 from pathlib import Path
 
+import numpy as np
 import pytest
 from PIL import Image
 
 from hpc_campaign.info import format_image_associations, format_info
 from hpc_campaign.manager import Manager
+from hpc_campaign.manager import main as manager_main
 from hpc_campaign.manager_args import ArgParser
 
 repo_root = Path(__file__).resolve().parents[1]
@@ -83,6 +86,184 @@ def test_manager_info_images_flag_is_parsed():
     assert parser.parse_next_command()
     assert parser.args.command == "info"
     assert parser.args.images is True
+
+
+def test_scalar_field_visualization_sequence(tmp_path: Path):
+    archive_name = "scalar_field_visualization.aca"
+    field = np.arange(12, dtype=np.float32).reshape(3, 4)
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(data_dir / "onearray.h5"), name="output")
+    manager.scalar_field_data(field, name="output/visualizations/temp/scalar.000000.raw")
+
+    visid = manager.visualization_sequence(
+        name="output/visualizations/temp",
+        vis_type="heatmap",
+        source_dataset="output",
+        variables=[{"name": "temp", "role": "primary"}],
+        items=[{"type": "SCALAR_FIELD", "name": "output/visualizations/temp/scalar.000000.raw"}],
+        metadata={"colormap": "viridis"},
+    )
+
+    assert visid > 0
+
+    info_data = manager.info(list_replicas=True, list_files=True)
+    scalar_dataset = next(dataset for dataset in info_data.datasets.values() if dataset.file_format == "SCALAR_FIELD")
+    assert scalar_dataset.name == "output/visualizations/temp/scalar.000000.raw"
+    assert scalar_dataset.metadata is not None
+    assert scalar_dataset.metadata["kind"] == "scalarField"
+    assert scalar_dataset.metadata["shape"] == [3, 4]
+    assert scalar_dataset.metadata["dtype"] == "float32"
+    assert scalar_dataset.metadata["compression"] == "none"
+    assert scalar_dataset.metadata["encoding"] == "raw"
+    assert scalar_dataset.metadata["min"] == 0.0
+    assert scalar_dataset.metadata["max"] == 11.0
+
+    sequence_info = next(iter(info_data.visualization_sequences.values()))
+    assert sequence_info.items[0].item_type == "SCALAR_FIELD"
+    assert sequence_info.items[0].dataset_name == scalar_dataset.name
+    assert sequence_info.items[0].file_format == "SCALAR_FIELD"
+
+    assoc_text = format_image_associations(info_data)
+    assert "output/visualizations/temp/scalar.000000.raw: SCALAR_FIELD" in assoc_text
+    assert "sequence: output/visualizations/temp" in assoc_text
+    assert "variables: primary=temp@output" in assoc_text
+
+    manager.close()
+
+
+def test_scalar_field_data_preserves_array_dtype_by_default(tmp_path: Path):
+    archive_name = "scalar_field_dtype.aca"
+    field = np.arange(6, dtype=np.float64).reshape(2, 3)
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.scalar_field_data(field, name="output/visualizations/temp/scalar.000000.raw")
+
+    info_data = manager.info(list_replicas=True, list_files=True)
+    scalar_dataset = next(dataset for dataset in info_data.datasets.values() if dataset.file_format == "SCALAR_FIELD")
+    assert scalar_dataset.metadata is not None
+    assert scalar_dataset.metadata["shape"] == [2, 3]
+    assert scalar_dataset.metadata["dtype"] == "float64"
+    assert scalar_dataset.metadata["min"] == 0.0
+    assert scalar_dataset.metadata["max"] == 5.0
+
+    manager.close()
+
+
+def test_scalar_field_data_shape_validates_array_shape(tmp_path: Path):
+    archive_name = "scalar_field_shape.aca"
+    field = np.arange(6, dtype=np.float32).reshape(2, 3)
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+
+    with pytest.raises(ValueError, match="does not match scalar field array shape"):
+        manager.scalar_field_data(field, shape=(3, 2), name="output/visualizations/temp/scalar.000000.raw")
+
+
+def test_scalar_field_data_bytes_require_shape_and_dtype(tmp_path: Path):
+    archive_name = "scalar_field_bytes.aca"
+    field = np.arange(6, dtype=np.float32).reshape(2, 3)
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+
+    with pytest.raises(ValueError, match="dtype is required"):
+        manager.scalar_field_data(
+            field.tobytes(),
+            shape=field.shape,
+            name="output/visualizations/temp/missing_dtype.raw",
+        )
+
+    with pytest.raises(ValueError, match="shape=\\[height, width\\] is required"):
+        manager.scalar_field_data(field.tobytes(), dtype="float32", name="output/visualizations/temp/missing_shape.raw")
+
+    manager.open(create=True, truncate=True)
+    manager.scalar_field_data(
+        field.tobytes(),
+        shape=field.shape,
+        dtype="float32",
+        name="output/visualizations/temp/scalar.000000.raw",
+    )
+    info_data = manager.info(list_replicas=True, list_files=True)
+    scalar_dataset = next(dataset for dataset in info_data.datasets.values() if dataset.file_format == "SCALAR_FIELD")
+    assert scalar_dataset.metadata is not None
+    assert scalar_dataset.metadata["shape"] == [2, 3]
+    assert scalar_dataset.metadata["dtype"] == "float32"
+
+    manager.close()
+
+
+def test_scalar_field_sequence_rejects_mismatched_shape_or_dtype(tmp_path: Path):
+    archive_name = "scalar_field_sequence_mismatch.aca"
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(data_dir / "onearray.h5"), name="output")
+
+    manager.scalar_field_data(
+        np.arange(6, dtype=np.float32).reshape(2, 3),
+        name="output/visualizations/temp/scalar.000000.raw",
+    )
+    manager.scalar_field_data(
+        np.arange(6, dtype=np.float32).reshape(3, 2),
+        name="output/visualizations/temp/scalar.000001.raw",
+    )
+    with pytest.raises(ValueError, match="compatible metadata"):
+        manager.visualization_sequence(
+            name="output/visualizations/temp_shape",
+            vis_type="heatmap",
+            source_dataset="output",
+            variables=[{"name": "temp", "role": "primary"}],
+            items=[
+                {"type": "SCALAR_FIELD", "name": "output/visualizations/temp/scalar.000000.raw"},
+                {"type": "SCALAR_FIELD", "name": "output/visualizations/temp/scalar.000001.raw"},
+            ],
+        )
+
+    manager.scalar_field_data(
+        np.arange(6, dtype=np.float64).reshape(2, 3),
+        name="output/visualizations/temp/scalar.000002.raw",
+    )
+    with pytest.raises(ValueError, match="compatible metadata"):
+        manager.visualization_sequence(
+            name="output/visualizations/temp_dtype",
+            vis_type="heatmap",
+            source_dataset="output",
+            variables=[{"name": "temp", "role": "primary"}],
+            items=[
+                {"type": "SCALAR_FIELD", "name": "output/visualizations/temp/scalar.000000.raw"},
+                {"type": "SCALAR_FIELD", "name": "output/visualizations/temp/scalar.000002.raw"},
+            ],
+        )
+
+    manager.close()
+
+
+def test_visualization_sequence_rejects_mixed_item_types(tmp_path: Path):
+    archive_name = "visualization_mixed_items.aca"
+    image_path = tmp_path / "thumb.png"
+    Image.new("RGB", (8, 8), color="green").save(image_path)
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.data(str(data_dir / "onearray.h5"), name="output")
+    manager.image(str(image_path), name="thumb")
+    manager.scalar_field_data(
+        np.arange(6, dtype=np.float32).reshape(2, 3),
+        name="output/visualizations/temp/scalar.000000.raw",
+    )
+
+    with pytest.raises(ValueError, match="mixed item types are not supported"):
+        manager.visualization_sequence(
+            name="output/visualizations/mixed",
+            vis_type="heatmap",
+            source_dataset="output",
+            variables=[{"name": "temp", "role": "primary"}],
+            items=[
+                {"type": "IMAGE", "name": "thumb"},
+                {"type": "SCALAR_FIELD", "name": "output/visualizations/temp/scalar.000000.raw"},
+            ],
+        )
+
+    manager.close()
 
 
 def test_visualization_sequence_multi_source_with_thumbnail(tmp_path: Path):
@@ -414,5 +595,147 @@ def test_visualization_axis_semantics_and_exact_sequence_name(tmp_path: Path):
         ("y-axis", "mass", "output"),
     ]
     assert sequence_info.items[0].dataset_name == "custom/sequence/name/image.000000.png"
+
+    manager.close()
+
+
+def test_scalar_field_cli_raw_file_requires_shape_and_dtype(tmp_path: Path):
+    archive_name = "scalar_field_cli_raw.aca"
+    raw_path = tmp_path / "scalar.raw"
+    field = np.arange(6, dtype=np.float32).reshape(2, 3)
+    raw_path.write_bytes(field.tobytes())
+
+    with pytest.raises(ValueError, match="dtype is required"):
+        manager_main(
+            args=[
+                "--campaign_store",
+                str(tmp_path),
+                "--truncate",
+                archive_name,
+                "scalar-field",
+                str(raw_path),
+                "--name",
+                "output/visualizations/temp/scalar.missing_dtype.raw",
+                "--shape",
+                "2",
+                "3",
+            ],
+            prog="hpc_campaign manager",
+        )
+
+    with pytest.raises(ValueError, match="shape=\\[height, width\\] is required"):
+        manager_main(
+            args=[
+                "--campaign_store",
+                str(tmp_path),
+                "--truncate",
+                archive_name,
+                "scalar-field",
+                str(raw_path),
+                "--name",
+                "output/visualizations/temp/scalar.missing_shape.raw",
+                "--dtype",
+                "float32",
+            ],
+            prog="hpc_campaign manager",
+        )
+
+    metadata_path = tmp_path / "scalar_metadata.json"
+    metadata_path.write_text(json.dumps({"source_step": 0}), encoding="utf-8")
+    manager_main(
+        args=[
+            "--campaign_store",
+            str(tmp_path),
+            "--truncate",
+            archive_name,
+            "scalar-field",
+            str(raw_path),
+            "--name",
+            "output/visualizations/temp/scalar.000000.raw",
+            "--shape",
+            "2",
+            "3",
+            "--dtype",
+            "float32",
+            "--value-encoding",
+            "direct",
+            "--metadata-json",
+            str(metadata_path),
+        ],
+        prog="hpc_campaign manager",
+    )
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    info_data = manager.info(list_replicas=True, list_files=True)
+    scalar_dataset = next(dataset for dataset in info_data.datasets.values() if dataset.file_format == "SCALAR_FIELD")
+    assert scalar_dataset.metadata is not None
+    assert scalar_dataset.metadata["shape"] == [2, 3]
+    assert scalar_dataset.metadata["dtype"] == "float32"
+    assert scalar_dataset.metadata["source_step"] == 0
+
+    manager.close()
+
+
+def test_scalar_field_cli_npy_and_visualization_sequence_manifest(tmp_path: Path):
+    archive_name = "scalar_field_cli_sequence.aca"
+    npy_path = tmp_path / "scalar.npy"
+    field = np.arange(6, dtype=np.float64).reshape(2, 3)
+    np.save(npy_path, field)
+
+    manifest_path = tmp_path / "sequence.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "name": "output/visualizations/temp_scalar_field",
+                "vis_type": "heatmap",
+                "source_dataset": "output",
+                "variables": [{"name": "temp", "role": "color-by"}],
+                "items": [
+                    {
+                        "type": "SCALAR_FIELD",
+                        "name": "output/visualizations/temp_scalar_field/scalar.000000.raw",
+                    }
+                ],
+                "metadata": {"colormap": "viridis"},
+                "replace": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager_main(
+        args=[
+            "--campaign_store",
+            str(tmp_path),
+            "--truncate",
+            archive_name,
+            "data",
+            str(data_dir / "onearray.h5"),
+            "--name",
+            "output",
+            "scalar-field",
+            str(npy_path),
+            "--name",
+            "output/visualizations/temp_scalar_field/scalar.000000.raw",
+            "visualization-sequence",
+            str(manifest_path),
+        ],
+        prog="hpc_campaign manager",
+    )
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    info_data = manager.info(list_replicas=True, list_files=True)
+    scalar_dataset = next(dataset for dataset in info_data.datasets.values() if dataset.file_format == "SCALAR_FIELD")
+    assert scalar_dataset.metadata is not None
+    assert scalar_dataset.metadata["shape"] == [2, 3]
+    assert scalar_dataset.metadata["dtype"] == "float64"
+
+    sequence_info = next(iter(info_data.visualization_sequences.values()))
+    assert sequence_info.name == "output/visualizations/temp_scalar_field"
+    assert sequence_info.items[0].item_type == "SCALAR_FIELD"
+    assert sequence_info.items[0].dataset_name == scalar_dataset.name
+    assert [(entry.role, entry.name, entry.source_dataset_name) for entry in sequence_info.variables] == [
+        ("color-by", "temp", "output")
+    ]
 
     manager.close()


### PR DESCRIPTION
## Summary

Adds first-class scalar field support to the visualization API and CLI.

## Changes

- Added `SCALAR_FIELD` as a supported dataset/visualization item type.
- Added `Manager.scalar_field_data()` for storing rank-2 NumPy arrays or raw scalar field bytes.
- Stores scalar field metadata including shape, dtype, byte order, layout, encoding, compression, min/max, and value encoding.
- Added validation for scalar field inputs:
  - NumPy arrays must be rank 2.
  - Raw bytes require explicit `shape` and `dtype`.
  - `shape` validates array shape instead of reshaping.
  - Unsupported layout, encoding, compression, and value encoding raise `ValueError`.
- Added scalar field visualization sequence validation:
  - Rejects mixed `IMAGE` / `SCALAR_FIELD` sequences.
  - Requires all scalar field frames in a sequence to have compatible shape, dtype, layout, encoding, compression, etc.
- Added CLI commands:
  - `scalar-field`
  - `visualization-sequence`
- Added JSON manifest support for CLI-created visualization sequences.
- Added `numpy` as a direct dependency.
- Updated CLI documentation with scalar field and visualization sequence examples.
- Added focused tests for correct and incorrect scalar field API/CLI usage.