### PR TITLE
Add schema for codes.

### DIFF
--- a/data/schema_examples/code_append_grid_append.yaml
+++ b/data/schema_examples/code_append_grid_append.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+name: code_append_grid_append
+
+files:
+  grid:
+    role: time_series
+    mode: append
+    path: grid.bp
+
+  fields:
+    role: time_series
+    mode: append
+    path: fields.bp
+    associations:
+      grid: grid
+
+time:
+  file: fields
+  variable: time

--- a/data/schema_examples/code_append_grid_multifile.yaml
+++ b/data/schema_examples/code_append_grid_multifile.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+name: code_append_grid_multifile
+
+files:
+  grid:
+    role: time_series
+    mode: append
+    path: grid.bp
+
+  fields:
+    role: time_series
+    mode: file_per_timestep
+    pattern: fields.*.bp
+    step_from_filename: 'fields\.(\d+)\.bp'
+    associations:
+      grid: grid
+
+time:
+  file: grid
+  variable: time

--- a/data/schema_examples/code_multifile.yaml
+++ b/data/schema_examples/code_multifile.yaml
@@ -1,0 +1,13 @@
+schema_version: 1
+name: code_multifile
+
+files:
+  fields:
+    role: time_series
+    mode: file_per_timestep
+    pattern: fields.*.bp
+    step_from_filename: 'fields\.(\d+)\.bp'
+
+time:
+  file: fields
+  index: step_index

--- a/data/schema_examples/code_single_append.yaml
+++ b/data/schema_examples/code_single_append.yaml
@@ -1,0 +1,12 @@
+schema_version: 1
+name: code_single_append
+
+files:
+  output:
+    role: time_series
+    mode: append
+    path: output.bp
+
+time:
+  file: output
+  variable: time

--- a/data/schema_examples/code_static_grid_append.yaml
+++ b/data/schema_examples/code_static_grid_append.yaml
@@ -1,0 +1,18 @@
+schema_version: 1
+name: code_static_grid_append
+
+files:
+  grid:
+    role: static
+    path: grid.bp
+
+  fields:
+    role: time_series
+    mode: append
+    path: fields.bp
+    associations:
+      grid: grid
+
+time:
+  file: fields
+  variable: time

--- a/data/schema_examples/code_static_grid_multifile.yaml
+++ b/data/schema_examples/code_static_grid_multifile.yaml
@@ -1,0 +1,19 @@
+schema_version: 1
+name: code_static_grid_multifile
+
+files:
+  grid:
+    role: static
+    path: grid.bp
+
+  fields:
+    role: time_series
+    mode: file_per_timestep
+    pattern: fields.*.bp
+    step_from_filename: 'fields\.(\d+)\.bp'
+    associations:
+      grid: grid
+
+time:
+  file: fields
+  index: step_index

--- a/data/schema_examples/code_xgc.yaml
+++ b/data/schema_examples/code_xgc.yaml
@@ -1,0 +1,49 @@
+schema_version: 1
+name: code_xgc
+
+files:
+  mesh:
+    role: static
+    path: xgc.mesh.bp
+
+  f0_mesh:
+    role: static
+    path: xgc.f0.mesh.bp
+
+  xgc_3d:
+    role: time_series
+    mode: file_per_timestep
+    pattern: xgc.3d.*.bp
+    step_from_filename: 'xgc\.3d\.(\d+)\.bp'
+    associations:
+      mesh: mesh
+    time:
+      variable: time
+
+  xgc_f3d:
+    role: time_series
+    mode: file_per_timestep
+    pattern: xgc.f3d.*.bp
+    step_from_filename: 'xgc\.f3d\.(\d+)\.bp'
+    associations:
+      mesh: mesh
+      f0_mesh: f0_mesh
+    time:
+      variable: time
+
+  xgc_fsourcediag:
+    role: time_series
+    mode: file_per_timestep
+    pattern: xgc.fsourcediag.*.bp
+    step_from_filename: 'xgc\.fsourcediag\.(\d+)\.bp'
+    associations:
+      mesh: mesh
+    time:
+      variable: time
+
+  xgc_oneddiag:
+    role: time_series
+    mode: append
+    path: xgc.oneddiag.bp
+    time:
+      variable: time

--- a/hpc_campaign/manager.py
+++ b/hpc_campaign/manager.py
@@ -12,12 +12,15 @@ import json
 import math
 import sqlite3
 import sys
+import zlib
 from io import BytesIO
 from os.path import exists
 from pathlib import Path
 from time import time_ns
 
+import nacl.secret
 import numpy as np
+import yaml
 from PIL import Image as PILImage
 
 from .info import InfoResult, collect_info, print_image_associations, print_info
@@ -38,6 +41,7 @@ from .manager_funcs import (
     set_default_args,
     update,
 )
+from .schema import SchemaInterpretationError, interpret_campaign_schema_layout
 from .upgrade import upgrade_aca
 from .utils import (
     check_campaign_store,
@@ -46,6 +50,7 @@ from .utils import (
 )
 
 CURRENT_TIME = time_ns()
+_CAMPAIGN_SCHEMA_NAME = "__campaign_schema.yaml"
 
 
 class Manager:  # pylint: disable=too-many-public-methods
@@ -190,6 +195,107 @@ class Manager:  # pylint: disable=too-many-public-methods
         if not self.connected:
             self.open(create=True, truncate=False)
         update(cmd_args, self.cur, self.con)
+
+    def set_schema(self, schema_file: str | Path):
+        schema_path = Path(schema_file).expanduser()
+        if not schema_path.is_file():
+            raise FileNotFoundError(f"Schema file not found: {schema_path}")
+        if schema_path.stat().st_size == 0:
+            raise ValueError(f"Schema file is empty: {schema_path}")
+        cmd_args = self._build_command_args(
+            "text",
+            {
+                "files": [str(schema_path)],
+                "name": _CAMPAIGN_SCHEMA_NAME,
+                "store": True,
+                "filename_as_recorded": _CAMPAIGN_SCHEMA_NAME,
+            },
+        )
+        if not self.connected:
+            self.open(create=True, truncate=False)
+        update(cmd_args, self.cur, self.con)
+
+    def validate_schema(self) -> dict:
+        if not self.connected:
+            self.open(create=False, truncate=False)
+
+        schema_text = self._read_embedded_schema_text()
+        try:
+            schema = yaml.safe_load(schema_text)
+        except yaml.YAMLError as exc:
+            raise SchemaInterpretationError(f"Invalid {_CAMPAIGN_SCHEMA_NAME}: {exc}") from exc
+        if not isinstance(schema, dict):
+            raise SchemaInterpretationError(f"{_CAMPAIGN_SCHEMA_NAME} must contain a mapping")
+
+        return interpret_campaign_schema_layout(
+            schema,
+            datasets=self._live_dataset_names(),
+            timeseries=self._time_series_membership(),
+        )
+
+    def _read_embedded_schema_text(self) -> str:
+        row = self.cur.execute(
+            """
+            select
+              r.keyid as keyid,
+              f.compression as compression,
+              f.data as data
+            from dataset as d
+            join replica as r on r.datasetid = d.rowid
+            join repfiles as rf on rf.replicaid = r.rowid
+            join file as f on f.fileid = rf.fileid
+            where d.name = ? and d.fileformat = 'TEXT' and d.deltime = 0 and r.deltime = 0
+            order by r.rowid desc, f.fileid desc
+            limit 1
+            """,
+            (_CAMPAIGN_SCHEMA_NAME,),
+        ).fetchone()
+
+        if row is None:
+            raise FileNotFoundError(f"{_CAMPAIGN_SCHEMA_NAME} is not stored in this campaign")
+
+        data = bytes(row["data"])
+        key_id = int(row["keyid"])
+        if key_id > 0:
+            if not self.args.encryption_key:
+                raise SchemaInterpretationError(
+                    f"{_CAMPAIGN_SCHEMA_NAME} is encrypted; open Manager with keyfile to validate"
+                )
+            box = nacl.secret.SecretBox(self.args.encryption_key)
+            data = box.decrypt(data)
+
+        if int(row["compression"]):
+            data = zlib.decompress(data)
+
+        return data.decode("utf-8")
+
+    def _live_dataset_names(self) -> list[str]:
+        rows = self.cur.execute(
+            """
+            select name
+            from dataset
+            where deltime = 0 and name != ?
+            order by name
+            """,
+            (_CAMPAIGN_SCHEMA_NAME,),
+        ).fetchall()
+        return [str(row["name"]) for row in rows]
+
+    def _time_series_membership(self) -> dict[str, list[str]]:
+        rows = self.cur.execute(
+            """
+            select t.name as timeseries_name, d.name as dataset_name
+            from timeseries as t
+            join dataset as d on d.tsid = t.tsid
+            where d.deltime = 0
+            order by t.name, d.tsorder
+            """
+        ).fetchall()
+
+        membership: dict[str, list[str]] = {}
+        for row in rows:
+            membership.setdefault(str(row["timeseries_name"]), []).append(str(row["dataset_name"]))
+        return membership
 
     def image(
         self,
@@ -930,6 +1036,8 @@ def main(args=None, prog=None):
             manager.data(parser.args.files, parser.args.name)
         elif parser.args.command == "text":
             manager.text(parser.args.files, parser.args.name, parser.args.store)
+        elif parser.args.command == "schema":
+            manager.set_schema(parser.args.schema_file)
         elif parser.args.command == "image":
             manager.image(parser.args.file, parser.args.name, parser.args.store, parser.args.thumbnail)
         elif parser.args.command == "scalar-field":

--- a/hpc_campaign/manager_args.py
+++ b/hpc_campaign/manager_args.py
@@ -9,6 +9,7 @@ __accepted_commands__ = [
     "info",
     "data",
     "text",
+    "schema",
     "image",
     "scalar-field",
     "visualization-sequence",
@@ -88,7 +89,7 @@ class ArgParser:
             if len(args.files) > 1:
                 raise ValueError("Invalid arguments for text: when using --name <name>, only one text file is allowed")
 
-    # pylint: disable=too-many-statements
+    # pylint: disable=too-many-locals,too-many-statements
     def setup_args(self, prog: str | None) -> dict:
         parser = argparse.ArgumentParser(
             prog=prog,
@@ -211,6 +212,17 @@ so be mindful about the size of the resulting archive. Text is stored compressed
             help="Representation name in the campaign hierarchy",
         )
         parser_text.add_argument("--store", "-s", help="Store image in campaign", action="store_true")
+
+        # parser for the "schema" command
+        parser_schema = argparse.ArgumentParser(
+            prog=f"{prog} <archive> schema",
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description="""
+Store a campaign ingestion schema as embedded __campaign_schema.yaml text.
+""",
+        )
+        parsers["schema"] = parser_schema
+        parser_schema.add_argument("schema_file", help="schema file to store in the campaign")
 
         # parser for the "image" command
         parser_image = argparse.ArgumentParser(
@@ -426,6 +438,8 @@ One may need to run upgrade several times to reach the newest format.
             del args.name
             del args.files
             del args.store
+        elif command == "schema":
+            del args.schema_file
         elif command == "image":
             del args.name
             del args.file

--- a/hpc_campaign/manager_funcs.py
+++ b/hpc_campaign/manager_funcs.py
@@ -840,7 +840,8 @@ def process_text_files(
         ds_id = add_dataset_to_archive(dataset, cur, unique_id, "TEXT", ct)
         rep_id = add_replica_to_archive(host_id, dir_id, 0, key_id, entry, cur, ds_id, ct, filesize, indent="  ")
         if args.store:
-            add_file_to_archive(args, entry, cur, rep_id, ct, basename(entry))
+            filename_as_recorded = str(getattr(args, "filename_as_recorded", "") or basename(entry))
+            add_file_to_archive(args, entry, cur, rep_id, ct, filename_as_recorded)
 
 
 def process_image(

--- a/hpc_campaign/schema.py
+++ b/hpc_campaign/schema.py
@@ -1,0 +1,328 @@
+import fnmatch
+import re
+from typing import Any, Mapping, Sequence
+
+
+class SchemaInterpretationError(ValueError):
+    """Raised when a schema cannot be interpreted against available datasets."""
+
+
+def interpret_schema_layout(
+    schema: Mapping[str, Any],
+    datasets: Sequence[str],
+    timeseries: Mapping[str, Sequence[str]] | None = None,
+) -> dict[str, Any]:
+    """
+    Interpret a minimal ingestion schema against known campaign dataset names.
+
+    This function resolves file groups, append vs file-per-timestep mode,
+    timestep extraction, group-level associations, and time references
+    normalized onto time-series groups. It intentionally does not open
+    ADIOS/HDF5 data.
+    """
+    schema_version = _schema_version(schema)
+    if schema_version != 1:
+        raise SchemaInterpretationError(f"Unsupported schema_version={schema_version}; expected 1")
+
+    files = _mapping(schema.get("files"), "files")
+    dataset_names = [str(name) for name in datasets]
+    timeseries_map = {str(name): [str(dataset) for dataset in values] for name, values in (timeseries or {}).items()}
+
+    file_groups: dict[str, dict[str, Any]] = {}
+    for group_name, raw_group in files.items():
+        group_key = str(group_name)
+        group = _mapping(raw_group, f"files.{group_key}")
+        file_groups[group_key] = _interpret_file_group(group_key, group, files, dataset_names, timeseries_map)
+
+    _apply_root_time(schema.get("time"), file_groups)
+
+    return {
+        "schema_version": schema_version,
+        "schema_name": str(schema.get("name", "") or ""),
+        "file_groups": file_groups,
+    }
+
+
+def interpret_campaign_schema_layout(
+    schema: Mapping[str, Any],
+    datasets: Sequence[str],
+    timeseries: Mapping[str, Sequence[str]] | None = None,
+) -> dict[str, Any]:
+    """
+    Interpret a schema against campaign dataset names.
+
+    First try the schema at campaign root. If it does not match root datasets,
+    apply the same schema independently to each immediate child directory by
+    resolving schema paths relative to that directory.
+    """
+    dataset_names = [str(name) for name in datasets]
+    timeseries_map = {str(name): [str(dataset) for dataset in values] for name, values in (timeseries or {}).items()}
+
+    try:
+        layout = interpret_schema_layout(schema, dataset_names, timeseries_map)
+        layout["scope"] = ""
+        return layout
+    except SchemaInterpretationError as root_error:
+        prefixes = _immediate_child_prefixes(dataset_names)
+        if not prefixes:
+            raise root_error
+
+    instances = {}
+    for prefix in prefixes:
+        scoped_datasets = _strip_scope_prefix(prefix, dataset_names)
+        scoped_timeseries = _strip_timeseries_scope_prefix(prefix, timeseries_map)
+        try:
+            scoped_layout = interpret_schema_layout(schema, scoped_datasets, scoped_timeseries)
+        except SchemaInterpretationError as exc:
+            raise SchemaInterpretationError(f"{prefix}: {exc}") from exc
+        instances[prefix] = _prefix_layout_datasets(prefix, scoped_layout)
+
+    return {
+        "schema_version": _schema_version(schema),
+        "schema_name": str(schema.get("name", "") or ""),
+        "instances": instances,
+    }
+
+
+def _immediate_child_prefixes(dataset_names: Sequence[str]) -> list[str]:
+    prefixes = {name.split("/", 1)[0] for name in dataset_names if "/" in name and name.split("/", 1)[0]}
+    return sorted(prefixes)
+
+
+def _strip_scope_prefix(prefix: str, dataset_names: Sequence[str]) -> list[str]:
+    prefix_slash = f"{prefix}/"
+    return [name[len(prefix_slash) :] for name in dataset_names if name.startswith(prefix_slash)]
+
+
+def _strip_timeseries_scope_prefix(
+    prefix: str,
+    timeseries: Mapping[str, Sequence[str]],
+) -> dict[str, list[str]]:
+    prefix_slash = f"{prefix}/"
+    scoped = {}
+    for name, datasets in timeseries.items():
+        scoped_datasets = [dataset[len(prefix_slash) :] for dataset in datasets if dataset.startswith(prefix_slash)]
+        if not scoped_datasets:
+            continue
+        scoped_name = name[len(prefix_slash) :] if name.startswith(prefix_slash) else name
+        scoped[scoped_name] = scoped_datasets
+    return scoped
+
+
+def _prefix_layout_datasets(prefix: str, layout: Mapping[str, Any]) -> dict[str, Any]:
+    prefixed_layout = dict(layout)
+    prefixed_layout["scope"] = prefix
+    file_groups = {}
+    for group_name, group in layout.get("file_groups", {}).items():
+        prefixed_group = dict(group)
+        prefixed_group["datasets"] = [f"{prefix}/{dataset}" for dataset in group.get("datasets", [])]
+        file_groups[group_name] = prefixed_group
+    prefixed_layout["file_groups"] = file_groups
+    return prefixed_layout
+
+
+def _schema_version(schema: Mapping[str, Any]) -> int:
+    try:
+        return int(schema.get("schema_version", 0))
+    except Exception as exc:
+        raise SchemaInterpretationError("schema_version must be an integer") from exc
+
+
+def _mapping(value: Any, field_name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SchemaInterpretationError(f"{field_name} must be a mapping")
+    return value
+
+
+def _nonempty_string(value: Any, field_name: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise SchemaInterpretationError(f"{field_name} is required")
+    return text
+
+
+def _interpret_file_group(
+    group_name: str,
+    group: Mapping[str, Any],
+    all_groups: Mapping[str, Any],
+    dataset_names: Sequence[str],
+    timeseries: Mapping[str, Sequence[str]],
+) -> dict[str, Any]:
+    role = _nonempty_string(group.get("role"), f"files.{group_name}.role")
+    if role not in {"static", "time_series"}:
+        raise SchemaInterpretationError(f"Unsupported files.{group_name}.role={role!r}")
+
+    associations = _interpret_associations(group_name, group.get("associations", {}), all_groups)
+
+    result: dict[str, Any]
+    if role == "static":
+        if "time" in group:
+            raise SchemaInterpretationError(f"files.{group_name}.time is only valid for time_series groups")
+        result = {
+            "role": role,
+            "mode": "none",
+            "datasets": _resolve_static_datasets(group_name, group, dataset_names),
+        }
+    else:
+        mode = _nonempty_string(group.get("mode"), f"files.{group_name}.mode")
+        if mode == "append":
+            result = {
+                "role": role,
+                "mode": mode,
+                "datasets": [_resolve_path_dataset(group_name, group, dataset_names)],
+            }
+        elif mode == "file_per_timestep":
+            datasets = _resolve_file_per_timestep_datasets(group_name, group, dataset_names, timeseries)
+            result = {
+                "role": role,
+                "mode": mode,
+                "datasets": datasets,
+                "step_indices": _extract_step_indices(group_name, group, datasets),
+            }
+        else:
+            raise SchemaInterpretationError(f"Unsupported files.{group_name}.mode={mode!r}")
+
+    if associations:
+        result["associations"] = associations
+    if "time" in group:
+        result["time"] = _interpret_group_time(group.get("time"), f"files.{group_name}.time")
+    return result
+
+
+def _resolve_static_datasets(group_name: str, group: Mapping[str, Any], dataset_names: Sequence[str]) -> list[str]:
+    if group.get("path"):
+        return [_resolve_path_dataset(group_name, group, dataset_names)]
+    pattern = _nonempty_string(group.get("pattern"), f"files.{group_name}.path or files.{group_name}.pattern")
+    matches = sorted(name for name in dataset_names if fnmatch.fnmatch(name, pattern))
+    if not matches:
+        raise SchemaInterpretationError(f"files.{group_name}.pattern matched no datasets: {pattern}")
+    return matches
+
+
+def _resolve_path_dataset(group_name: str, group: Mapping[str, Any], dataset_names: Sequence[str]) -> str:
+    path = _nonempty_string(group.get("path"), f"files.{group_name}.path")
+    if path not in dataset_names:
+        raise SchemaInterpretationError(f"files.{group_name}.path does not match a dataset: {path}")
+    return path
+
+
+def _resolve_file_per_timestep_datasets(
+    group_name: str,
+    group: Mapping[str, Any],
+    dataset_names: Sequence[str],
+    timeseries: Mapping[str, Sequence[str]],
+) -> list[str]:
+    pattern = _nonempty_string(group.get("pattern"), f"files.{group_name}.pattern")
+    matches = {name for name in dataset_names if fnmatch.fnmatch(name, pattern)}
+    if not matches:
+        raise SchemaInterpretationError(f"files.{group_name}.pattern matched no datasets: {pattern}")
+
+    if group_name not in timeseries:
+        return sorted(matches)
+
+    ordered = []
+    for dataset in timeseries[group_name]:
+        if dataset not in dataset_names:
+            raise SchemaInterpretationError(f"timeseries.{group_name} references missing dataset: {dataset}")
+        if dataset not in matches:
+            raise SchemaInterpretationError(
+                f"timeseries.{group_name} dataset does not match files.{group_name}.pattern: {dataset}"
+            )
+        ordered.append(dataset)
+    if not ordered:
+        raise SchemaInterpretationError(f"timeseries.{group_name} is empty")
+    return ordered
+
+
+def _extract_step_indices(group_name: str, group: Mapping[str, Any], datasets: Sequence[str]) -> list[int]:
+    pattern = _nonempty_string(group.get("step_from_filename"), f"files.{group_name}.step_from_filename")
+    try:
+        regex = re.compile(pattern)
+    except re.error as exc:
+        raise SchemaInterpretationError(f"Invalid files.{group_name}.step_from_filename regex: {exc}") from exc
+
+    steps = []
+    for dataset in datasets:
+        match = regex.search(dataset)
+        if match is None:
+            raise SchemaInterpretationError(f"files.{group_name}.step_from_filename did not match dataset: {dataset}")
+        if not match.groups():
+            raise SchemaInterpretationError(f"files.{group_name}.step_from_filename must capture a step number")
+        try:
+            steps.append(int(match.group(1)))
+        except Exception as exc:
+            raise SchemaInterpretationError(
+                f"files.{group_name}.step_from_filename captured a non-integer step for {dataset}: {match.group(1)}"
+            ) from exc
+    return steps
+
+
+def _interpret_associations(
+    group_name: str,
+    associations: Any,
+    all_groups: Mapping[str, Any],
+) -> dict[str, str]:
+    if associations in (None, {}):
+        return {}
+    assoc_map = _mapping(associations, f"files.{group_name}.associations")
+    result = {}
+    for role, target in assoc_map.items():
+        target_group = _nonempty_string(target, f"files.{group_name}.associations.{role}")
+        if target_group not in all_groups:
+            raise SchemaInterpretationError(
+                f"files.{group_name}.associations.{role} references unknown group: {target_group}"
+            )
+        result[str(role)] = target_group
+    return result
+
+
+def _interpret_time_fields(time_spec: Any, field_name: str) -> dict[str, str]:
+    time_map = _mapping(time_spec, field_name)
+    variable = str(time_map.get("variable", "") or "").strip()
+    index = str(time_map.get("index", "") or "").strip()
+    has_variable = bool(variable)
+    has_index = bool(index)
+    if has_variable == has_index:
+        raise SchemaInterpretationError(f"{field_name} requires exactly one of variable or index")
+
+    if has_variable:
+        return {"variable": variable}
+    return {"index": index}
+
+
+def _interpret_group_time(time_spec: Any, field_name: str) -> dict[str, str]:
+    time_map = _mapping(time_spec, field_name)
+    if "file" in time_map:
+        raise SchemaInterpretationError(f"{field_name}.file is not supported; file group is implicit")
+    return _interpret_time_fields(time_map, field_name)
+
+
+def _interpret_root_time(time_spec: Any, file_groups: Mapping[str, dict[str, Any]]) -> dict[str, str]:
+    time_map = _mapping(time_spec, "time")
+    result = _interpret_time_fields(time_map, "time")
+    if "file" in time_map:
+        file_group = _nonempty_string(time_map.get("file"), "time.file")
+        group = file_groups.get(file_group)
+        if group is None:
+            raise SchemaInterpretationError(f"time.file references unknown group: {file_group}")
+        if group.get("role") != "time_series":
+            raise SchemaInterpretationError(f"time.file references non-time_series group: {file_group}")
+        result["file"] = file_group
+    return result
+
+
+def _apply_root_time(time_spec: Any, file_groups: dict[str, dict[str, Any]]) -> None:
+    if time_spec in (None, {}):
+        return
+
+    root_time = _interpret_root_time(time_spec, file_groups)
+    root_group = root_time.get("file", "")
+    group_time = {key: value for key, value in root_time.items() if key != "file"}
+
+    if root_group:
+        file_groups[root_group].setdefault("time", dict(group_time))
+        return
+
+    for group in file_groups.values():
+        if group.get("role") == "time_series":
+            group.setdefault("time", dict(group_time))

--- a/hpc_campaign/utils.py
+++ b/hpc_campaign/utils.py
@@ -166,7 +166,7 @@ def set_default_args_from_config(args: Namespace, read_host_config: bool = False
     return args
 
 
-sql_error_list = []
+sql_error_list: list[sqlite3.OperationalError] = []
 
 
 def sql_execute(cur: sqlite3.Cursor, cmd: str, parameters=()) -> sqlite3.Cursor:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,215 @@
+import sqlite3
+import subprocess
+import sys
+import zlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hpc_campaign.manager import Manager
+from hpc_campaign.manager_args import ArgParser
+
+# These tests cover the first schema-storage layer only. hpc_campaign stores
+# __campaign_schema.yaml as embedded TEXT; downstream ingestion code interprets its
+# layout semantics. The assertions here check API/CLI storage, update behavior,
+# example fixture coverage, and coexistence with the existing timeseries table.
+# They do not validate file patterns, append/file-per-timestep semantics, grid
+# associations, or nested schema override rules; schema validation is tested
+# separately in test_schema_validation.py.
+repo_root = Path(__file__).resolve().parents[1]
+data_dir = repo_root / "data"
+schema_examples_dir = data_dir / "schema_examples"
+
+
+def read_embedded_text(archive_path: Path, dataset_name: str = "__campaign_schema.yaml") -> tuple[str, dict]:
+    # Inspect the ACA tables directly so the tests verify the actual embedded
+    # archive payload, not just the public Manager call path.
+    con = sqlite3.connect(str(archive_path))
+    con.row_factory = sqlite3.Row
+    try:
+        row = con.execute(
+            """
+            select
+              d.name as dataset_name,
+              d.fileformat as fileformat,
+              r.name as replica_name,
+              f.name as file_name,
+              f.compression as compression,
+              f.data as data
+            from dataset as d
+            join replica as r on r.datasetid = d.rowid
+            join repfiles as rf on rf.replicaid = r.rowid
+            join file as f on f.fileid = rf.fileid
+            where d.name = ? and d.deltime = 0 and r.deltime = 0
+            order by r.rowid desc, f.fileid desc
+            limit 1
+            """,
+            (dataset_name,),
+        ).fetchone()
+    finally:
+        con.close()
+
+    assert row is not None
+    raw = bytes(row["data"])
+    text = zlib.decompress(raw).decode("utf-8") if int(row["compression"]) else raw.decode("utf-8")
+    return text, dict(row)
+
+
+def schema_example_paths() -> list[Path]:
+    # Keep the examples discoverable so adding a new code_*.yaml fixture
+    # automatically exercises schema storage for that layout.
+    return sorted(schema_examples_dir.glob("code_*.yaml"))
+
+
+def run_manager_command(campaign_store: Path, args: list[str]) -> subprocess.CompletedProcess:
+    # Exercise the installed CLI entry point in a subprocess, matching the
+    # existing manager CLI tests.
+    command = [
+        sys.executable,
+        "-m",
+        "hpc_campaign",
+        "manager",
+        "--campaign_store",
+        str(campaign_store),
+    ]
+    command.extend([str(entry) for entry in args])
+    return subprocess.run(command, check=True, capture_output=True, text=True)
+
+
+def test_schema_command_is_parsed():
+    # The manager command splitter needs to recognize schema as its own command,
+    # otherwise later commands can consume its arguments incorrectly.
+    parser = ArgParser(args=["demo.aca", "schema", "__campaign_schema.yaml"], prog="hpc_campaign manager")
+    assert parser.parse_next_command()
+    assert parser.args.command == "schema"
+    assert parser.args.schema_file == "__campaign_schema.yaml"
+
+
+@pytest.mark.parametrize("schema_path", schema_example_paths(), ids=lambda p: p.stem)
+def test_set_schema_stores_example_as_embedded_campaign_schema_yaml(tmp_path: Path, schema_path: Path):
+    # Every example schema should be stored under the fixed campaign dataset
+    # name __campaign_schema.yaml, regardless of where the source file lives on disk.
+    archive_name = f"{schema_path.stem}.aca"
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.set_schema(schema_path)
+    manager.close()
+
+    text, stored = read_embedded_text(tmp_path / archive_name)
+    schema = yaml.safe_load(text)
+
+    assert stored["dataset_name"] == "__campaign_schema.yaml"
+    assert stored["fileformat"] == "TEXT"
+    assert stored["file_name"] == "__campaign_schema.yaml"
+    assert schema["schema_version"] == 1
+    assert schema["name"] == schema_path.stem
+    assert isinstance(schema["files"], dict)
+
+
+def test_schema_cli_stores_campaign_schema_yaml(tmp_path: Path):
+    # The CLI should behave the same as Manager.set_schema and produce an
+    # embedded TEXT dataset named __campaign_schema.yaml.
+    archive_name = "schema_cli.aca"
+    schema_path = schema_examples_dir / "code_single_append.yaml"
+
+    run_manager_command(tmp_path, [archive_name, "schema", str(schema_path)])
+
+    text, stored = read_embedded_text(tmp_path / archive_name)
+    schema = yaml.safe_load(text)
+
+    assert stored["dataset_name"] == "__campaign_schema.yaml"
+    assert stored["fileformat"] == "TEXT"
+    assert schema["name"] == "code_single_append"
+
+
+def test_set_schema_updates_existing_embedded_content(tmp_path: Path):
+    # Re-registering __campaign_schema.yaml is expected during schema iteration. The
+    # existing replica/file path should be updated rather than leaving stale
+    # embedded content behind.
+    archive_name = "schema_update.aca"
+    schema_path = tmp_path / "__campaign_schema.yaml"
+    schema_path.write_text(
+        "schema_version: 1\n"
+        "name: first\n"
+        "files:\n"
+        "  output:\n"
+        "    role: time_series\n"
+        "    mode: append\n"
+        "    path: output.bp\n",
+        encoding="utf-8",
+    )
+
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.set_schema(schema_path)
+
+    schema_path.write_text(
+        "schema_version: 1\n"
+        "name: second\n"
+        "files:\n"
+        "  output:\n"
+        "    role: time_series\n"
+        "    mode: append\n"
+        "    path: updated.bp\n",
+        encoding="utf-8",
+    )
+    manager.set_schema(schema_path)
+    manager.close()
+
+    text, _stored = read_embedded_text(tmp_path / archive_name)
+    schema = yaml.safe_load(text)
+
+    assert schema["name"] == "second"
+    assert schema["files"]["output"]["path"] == "updated.bp"
+
+
+def test_schema_coexists_with_existing_time_series(tmp_path: Path):
+    # Multifile layouts still use the existing timeseries table for ordered
+    # dataset membership. The schema describes layout/associations and should
+    # not interfere with that zero-based ordering.
+    archive_name = "schema_timeseries.aca"
+    schema_path = schema_examples_dir / "code_append_grid_multifile.yaml"
+    fields = ["fields.0000.bp", "fields.0001.bp"]
+
+    # Build a small campaign that has both new schema metadata and the existing
+    # ordered timeseries metadata. onearray.h5 is reused as stand-in data; the
+    # dataset names are what matter for this storage-level test.
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.set_schema(schema_path)
+    manager.data(data_dir / "onearray.h5", name="grid.bp")
+    for field_name in fields:
+        manager.data(data_dir / "onearray.h5", name=field_name)
+    manager.add_time_series("fields", fields, replace=True)
+    manager.close()
+
+    text, stored = read_embedded_text(tmp_path / archive_name)
+    schema = yaml.safe_load(text)
+
+    # Confirm the schema remains a normal embedded TEXT dataset named
+    # __campaign_schema.yaml, even when the same campaign also has a timeseries.
+    assert stored["dataset_name"] == "__campaign_schema.yaml"
+    assert schema["name"] == "code_append_grid_multifile"
+
+    # Check the existing timeseries tables directly. This verifies that
+    # set_schema() did not alter the current tsid/tsorder representation.
+    con = sqlite3.connect(str(tmp_path / archive_name))
+    try:
+        rows = con.execute(
+            """
+            select t.name, d.name, d.tsorder
+            from timeseries as t
+            join dataset as d on d.tsid = t.tsid
+            where t.name = ?
+            order by d.tsorder
+            """,
+            ("fields",),
+        ).fetchall()
+    finally:
+        con.close()
+
+    assert [(row[0], row[1], row[2]) for row in rows] == [
+        ("fields", "fields.0000.bp", 0),
+        ("fields", "fields.0001.bp", 1),
+    ]

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,0 +1,624 @@
+from pathlib import Path
+
+import pytest
+
+from hpc_campaign.manager import Manager
+from hpc_campaign.schema import SchemaInterpretationError
+
+# These tests are the campaign-level schema validation tests. They build real
+# ACA files with Manager, store __campaign_schema.yaml, register named datasets, and then
+# call Manager.validate_schema().
+#
+# Validation here is metadata-only: schema paths and patterns must resolve to
+# live dataset names in the ACA, and file-per-timestep groups may use the
+# existing timeseries table for ordering. Extra campaign datasets are allowed.
+# If a root schema does not match root-level datasets, it is applied to each
+# immediate child directory as a separate run instance. These tests intentionally
+# do not open ADIOS/HDF5 payloads or check variables inside data files.
+repo_root = Path(__file__).resolve().parents[1]
+data_dir = repo_root / "data"
+schema_examples_dir = data_dir / "schema_examples"
+sample_dataset = data_dir / "onearray.h5"
+
+
+def schema_path(name: str) -> Path:
+    # Each code_*.yaml fixture describes one supported layout shape. Manager
+    # stores any selected fixture into the ACA as __campaign_schema.yaml.
+    return schema_examples_dir / f"{name}.yaml"
+
+
+def add_named_datasets(manager: Manager, dataset_names: list[str]):
+    # Reuse one small HDF5 file for all logical dataset names. The validation
+    # logic only needs ACA metadata names, not the file payload.
+    for dataset_name in dataset_names:
+        manager.data(sample_dataset, name=dataset_name)
+
+
+def build_campaign(tmp_path: Path, archive_name: str, schema_name: str, dataset_names: list[str]) -> Manager:
+    # Common setup: create an ACA, embed __campaign_schema.yaml, and register the datasets
+    # that validation should match against the schema.
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.set_schema(schema_path(schema_name))
+    add_named_datasets(manager, dataset_names)
+    return manager
+
+
+def build_campaign_from_schema_text(
+    tmp_path: Path,
+    archive_name: str,
+    schema_text: str,
+    dataset_names: list[str],
+) -> Manager:
+    schema_file = tmp_path / f"{archive_name}.__campaign_schema.yaml"
+    schema_file.write_text(schema_text, encoding="utf-8")
+    manager = Manager(archive=archive_name, campaign_store=str(tmp_path))
+    manager.open(create=True, truncate=True)
+    manager.set_schema(schema_file)
+    add_named_datasets(manager, dataset_names)
+    return manager
+
+
+def test_validate_schema_single_append_allows_extra_campaign_datasets(tmp_path: Path):
+    # The schema requires output.bp. extra.bp proves validation is not a closed
+    # world check: unrelated campaign datasets are ignored.
+    manager = build_campaign(
+        tmp_path,
+        "single_append.aca",
+        "code_single_append",
+        ["output.bp", "extra.bp"],
+    )
+
+    layout = manager.validate_schema()
+    manager.close()
+
+    assert layout["schema_name"] == "code_single_append"
+    assert layout["file_groups"]["output"] == {
+        "role": "time_series",
+        "mode": "append",
+        "datasets": ["output.bp"],
+        "time": {"variable": "time"},
+    }
+
+
+def test_validate_schema_root_schema_applies_to_each_run_directory(tmp_path: Path):
+    # The root schema is written in run-relative terms: path output.bp. Since no
+    # root-level output.bp exists, validation applies the schema independently to
+    # run1/ and run2/.
+    manager = build_campaign(
+        tmp_path,
+        "multi_run_single_append.aca",
+        "code_single_append",
+        ["run1/output.bp", "run2/output.bp", "notes.txt"],
+    )
+
+    layout = manager.validate_schema()
+    manager.close()
+
+    assert sorted(layout["instances"]) == ["run1", "run2"]
+    assert layout["instances"]["run1"]["file_groups"]["output"]["datasets"] == ["run1/output.bp"]
+    assert layout["instances"]["run2"]["file_groups"]["output"]["datasets"] == ["run2/output.bp"]
+
+
+def test_validate_schema_multifile_uses_existing_timeseries_order(tmp_path: Path):
+    # The schema pattern finds both field datasets. The existing timeseries table
+    # supplies the order, and step_from_filename extracts [0, 1].
+    manager = build_campaign(
+        tmp_path,
+        "multifile.aca",
+        "code_multifile",
+        ["fields.0001.bp", "fields.0000.bp"],
+    )
+    manager.add_time_series("fields", ["fields.0000.bp", "fields.0001.bp"], replace=True)
+
+    layout = manager.validate_schema()
+    manager.close()
+
+    assert layout["schema_name"] == "code_multifile"
+    assert layout["file_groups"]["fields"] == {
+        "role": "time_series",
+        "mode": "file_per_timestep",
+        "datasets": ["fields.0000.bp", "fields.0001.bp"],
+        "step_indices": [0, 1],
+        "time": {"index": "step_index"},
+    }
+
+
+def test_validate_schema_run_directories_use_scoped_timeseries_order(tmp_path: Path):
+    # Scoped timeseries names let each run directory define its own ordered list
+    # for the same schema file group.
+    manager = build_campaign(
+        tmp_path,
+        "multi_run_multifile.aca",
+        "code_multifile",
+        [
+            "run1/fields.0001.bp",
+            "run1/fields.0000.bp",
+            "run2/fields.0001.bp",
+            "run2/fields.0000.bp",
+        ],
+    )
+    manager.add_time_series("run1/fields", ["run1/fields.0000.bp", "run1/fields.0001.bp"], replace=True)
+    manager.add_time_series("run2/fields", ["run2/fields.0000.bp", "run2/fields.0001.bp"], replace=True)
+
+    layout = manager.validate_schema()
+    manager.close()
+
+    assert layout["instances"]["run1"]["file_groups"]["fields"] == {
+        "role": "time_series",
+        "mode": "file_per_timestep",
+        "datasets": ["run1/fields.0000.bp", "run1/fields.0001.bp"],
+        "step_indices": [0, 1],
+        "time": {"index": "step_index"},
+    }
+    assert layout["instances"]["run2"]["file_groups"]["fields"] == {
+        "role": "time_series",
+        "mode": "file_per_timestep",
+        "datasets": ["run2/fields.0000.bp", "run2/fields.0001.bp"],
+        "step_indices": [0, 1],
+        "time": {"index": "step_index"},
+    }
+
+
+def test_validate_schema_static_grid_append_fields(tmp_path: Path):
+    # Static grid plus append-mode fields: both schema paths must exist in the
+    # ACA, and fields keep their association to the grid file group.
+    manager = build_campaign(
+        tmp_path,
+        "static_grid_append.aca",
+        "code_static_grid_append",
+        ["grid.bp", "fields.bp"],
+    )
+
+    layout = manager.validate_schema()
+    manager.close()
+
+    assert layout["file_groups"]["grid"] == {
+        "role": "static",
+        "mode": "none",
+        "datasets": ["grid.bp"],
+    }
+    assert layout["file_groups"]["fields"] == {
+        "role": "time_series",
+        "mode": "append",
+        "datasets": ["fields.bp"],
+        "associations": {"grid": "grid"},
+        "time": {"variable": "time"},
+    }
+
+
+def test_validate_schema_static_grid_multifile_fields(tmp_path: Path):
+    # Static grid plus one-file-per-timestep fields: the grid path is a single
+    # registered dataset, while field files are ordered by timeseries metadata.
+    manager = build_campaign(
+        tmp_path,
+        "static_grid_multifile.aca",
+        "code_static_grid_multifile",
+        ["grid.bp", "fields.0001.bp", "fields.0000.bp"],
+    )
+    manager.add_time_series("fields", ["fields.0000.bp", "fields.0001.bp"], replace=True)
+
+    layout = manager.validate_schema()
+    manager.close()
+
+    assert layout["file_groups"]["grid"] == {
+        "role": "static",
+        "mode": "none",
+        "datasets": ["grid.bp"],
+    }
+    assert layout["file_groups"]["fields"] == {
+        "role": "time_series",
+        "mode": "file_per_timestep",
+        "datasets": ["fields.0000.bp", "fields.0001.bp"],
+        "step_indices": [0, 1],
+        "associations": {"grid": "grid"},
+        "time": {"index": "step_index"},
+    }
+
+
+def test_validate_schema_append_grid_append_fields(tmp_path: Path):
+    # A grid does not have to be static. This validates an append-mode grid
+    # associated with append-mode fields.
+    manager = build_campaign(
+        tmp_path,
+        "append_grid_append.aca",
+        "code_append_grid_append",
+        ["grid.bp", "fields.bp"],
+    )
+
+    layout = manager.validate_schema()
+    manager.close()
+
+    assert layout["file_groups"]["grid"] == {
+        "role": "time_series",
+        "mode": "append",
+        "datasets": ["grid.bp"],
+    }
+    assert layout["file_groups"]["fields"]["associations"] == {"grid": "grid"}
+    assert layout["file_groups"]["fields"]["time"] == {"variable": "time"}
+
+
+def test_validate_schema_append_grid_multifile_fields(tmp_path: Path):
+    # Mixed layout: append-mode grid data plus fields stored as one dataset per
+    # timestep. The field order still comes from the existing timeseries table.
+    manager = build_campaign(
+        tmp_path,
+        "append_grid_multifile.aca",
+        "code_append_grid_multifile",
+        ["grid.bp", "fields.0001.bp", "fields.0000.bp"],
+    )
+    manager.add_time_series("fields", ["fields.0000.bp", "fields.0001.bp"], replace=True)
+
+    layout = manager.validate_schema()
+    manager.close()
+
+    assert layout["file_groups"]["grid"] == {
+        "role": "time_series",
+        "mode": "append",
+        "datasets": ["grid.bp"],
+        "time": {"variable": "time"},
+    }
+    assert layout["file_groups"]["fields"] == {
+        "role": "time_series",
+        "mode": "file_per_timestep",
+        "datasets": ["fields.0000.bp", "fields.0001.bp"],
+        "step_indices": [0, 1],
+        "associations": {"grid": "grid"},
+    }
+
+
+def test_validate_schema_root_time_without_file_applies_to_all_time_series_groups(tmp_path: Path):
+    schema_text = """
+schema_version: 1
+name: root_time_default
+
+files:
+  grid:
+    role: static
+    path: grid.bp
+
+  fields:
+    role: time_series
+    mode: append
+    path: fields.bp
+
+  diagnostics:
+    role: time_series
+    mode: append
+    path: diagnostics.bp
+
+time:
+  variable: time
+"""
+    manager = build_campaign_from_schema_text(
+        tmp_path,
+        "root_time_default.aca",
+        schema_text,
+        ["grid.bp", "fields.bp", "diagnostics.bp"],
+    )
+
+    layout = manager.validate_schema()
+    manager.close()
+
+    assert "time" not in layout["file_groups"]["grid"]
+    assert layout["file_groups"]["fields"]["time"] == {"variable": "time"}
+    assert layout["file_groups"]["diagnostics"]["time"] == {"variable": "time"}
+
+
+def test_validate_schema_group_time_overrides_root_default(tmp_path: Path):
+    schema_text = """
+schema_version: 1
+name: group_time_override
+
+files:
+  fields:
+    role: time_series
+    mode: append
+    path: fields.bp
+    time:
+      variable: physical_time
+
+  diagnostics:
+    role: time_series
+    mode: append
+    path: diagnostics.bp
+
+time:
+  variable: time
+"""
+    manager = build_campaign_from_schema_text(
+        tmp_path,
+        "group_time_override.aca",
+        schema_text,
+        ["fields.bp", "diagnostics.bp"],
+    )
+
+    layout = manager.validate_schema()
+    manager.close()
+
+    assert layout["file_groups"]["fields"]["time"] == {"variable": "physical_time"}
+    assert layout["file_groups"]["diagnostics"]["time"] == {"variable": "time"}
+
+
+def test_validate_schema_xgc(tmp_path: Path):
+    manager = build_campaign(
+        tmp_path,
+        "xgc.aca",
+        "code_xgc",
+        [
+            "xgc.mesh.bp",
+            "xgc.f0.mesh.bp",
+            "xgc.3d.00010.bp",
+            "xgc.3d.00012.bp",
+            "xgc.f3d.00010.bp",
+            "xgc.f3d.00012.bp",
+            "xgc.fsourcediag.00010.bp",
+            "xgc.fsourcediag.00012.bp",
+            "xgc.oneddiag.bp",
+        ],
+    )
+    manager.add_time_series("xgc_3d", ["xgc.3d.00010.bp", "xgc.3d.00012.bp"], replace=True)
+    manager.add_time_series("xgc_f3d", ["xgc.f3d.00010.bp", "xgc.f3d.00012.bp"], replace=True)
+    manager.add_time_series(
+        "xgc_fsourcediag",
+        ["xgc.fsourcediag.00010.bp", "xgc.fsourcediag.00012.bp"],
+        replace=True,
+    )
+
+    layout = manager.validate_schema()
+    manager.close()
+
+    assert layout["file_groups"]["mesh"] == {
+        "role": "static",
+        "mode": "none",
+        "datasets": ["xgc.mesh.bp"],
+    }
+    assert layout["file_groups"]["f0_mesh"] == {
+        "role": "static",
+        "mode": "none",
+        "datasets": ["xgc.f0.mesh.bp"],
+    }
+    assert layout["file_groups"]["xgc_3d"] == {
+        "role": "time_series",
+        "mode": "file_per_timestep",
+        "datasets": ["xgc.3d.00010.bp", "xgc.3d.00012.bp"],
+        "step_indices": [10, 12],
+        "associations": {"mesh": "mesh"},
+        "time": {"variable": "time"},
+    }
+    assert layout["file_groups"]["xgc_f3d"] == {
+        "role": "time_series",
+        "mode": "file_per_timestep",
+        "datasets": ["xgc.f3d.00010.bp", "xgc.f3d.00012.bp"],
+        "step_indices": [10, 12],
+        "associations": {"mesh": "mesh", "f0_mesh": "f0_mesh"},
+        "time": {"variable": "time"},
+    }
+    assert layout["file_groups"]["xgc_fsourcediag"] == {
+        "role": "time_series",
+        "mode": "file_per_timestep",
+        "datasets": ["xgc.fsourcediag.00010.bp", "xgc.fsourcediag.00012.bp"],
+        "step_indices": [10, 12],
+        "associations": {"mesh": "mesh"},
+        "time": {"variable": "time"},
+    }
+    assert layout["file_groups"]["xgc_oneddiag"] == {
+        "role": "time_series",
+        "mode": "append",
+        "datasets": ["xgc.oneddiag.bp"],
+        "time": {"variable": "time"},
+    }
+
+
+def test_validate_schema_fails_when_required_path_dataset_is_missing(tmp_path: Path):
+    # A schema path is mandatory. code_static_grid_append names grid.bp, so a
+    # campaign containing only fields.bp is invalid.
+    manager = build_campaign(
+        tmp_path,
+        "missing_grid.aca",
+        "code_static_grid_append",
+        ["fields.bp"],
+    )
+
+    with pytest.raises(SchemaInterpretationError, match="files.grid.path"):
+        manager.validate_schema()
+    manager.close()
+
+
+def test_validate_schema_fails_when_pattern_matches_no_campaign_dataset(tmp_path: Path):
+    # A file-per-timestep pattern must match at least one live ACA dataset.
+    # Unrelated datasets do not satisfy the file group.
+    manager = build_campaign(
+        tmp_path,
+        "missing_pattern.aca",
+        "code_multifile",
+        ["other.0000.bp"],
+    )
+
+    with pytest.raises(SchemaInterpretationError, match="matched no datasets"):
+        manager.validate_schema()
+    manager.close()
+
+
+def test_validate_schema_fails_when_any_run_directory_does_not_match_schema(tmp_path: Path):
+    # Every immediate child directory is treated as an instance of the root
+    # schema. run2/ is missing output.bp, so the campaign is invalid.
+    manager = build_campaign(
+        tmp_path,
+        "multi_run_missing_output.aca",
+        "code_single_append",
+        ["run1/output.bp", "run2/not_output.bp"],
+    )
+
+    with pytest.raises(SchemaInterpretationError, match="run2: files.output.path"):
+        manager.validate_schema()
+    manager.close()
+
+
+def test_validate_schema_fails_when_timeseries_member_does_not_match_pattern(tmp_path: Path):
+    # Timeseries membership cannot smuggle unrelated datasets into a file group;
+    # every ordered member must still match the schema pattern.
+    manager = build_campaign(
+        tmp_path,
+        "bad_timeseries.aca",
+        "code_multifile",
+        ["fields.0000.bp", "other.0001.bp"],
+    )
+    manager.add_time_series("fields", ["fields.0000.bp", "other.0001.bp"], replace=True)
+
+    with pytest.raises(SchemaInterpretationError, match="does not match"):
+        manager.validate_schema()
+    manager.close()
+
+
+def test_validate_schema_fails_when_static_group_has_time(tmp_path: Path):
+    schema_text = """
+schema_version: 1
+name: static_group_time
+
+files:
+  grid:
+    role: static
+    path: grid.bp
+    time:
+      variable: time
+"""
+    manager = build_campaign_from_schema_text(
+        tmp_path,
+        "static_group_time.aca",
+        schema_text,
+        ["grid.bp"],
+    )
+
+    with pytest.raises(SchemaInterpretationError, match="files.grid.time is only valid for time_series groups"):
+        manager.validate_schema()
+    manager.close()
+
+
+def test_validate_schema_fails_when_group_time_has_no_source(tmp_path: Path):
+    schema_text = """
+schema_version: 1
+name: group_time_no_source
+
+files:
+  fields:
+    role: time_series
+    mode: append
+    path: fields.bp
+    time: {}
+"""
+    manager = build_campaign_from_schema_text(
+        tmp_path,
+        "group_time_no_source.aca",
+        schema_text,
+        ["fields.bp"],
+    )
+
+    with pytest.raises(SchemaInterpretationError, match="files.fields.time requires exactly one"):
+        manager.validate_schema()
+    manager.close()
+
+
+def test_validate_schema_fails_when_group_time_has_variable_and_index(tmp_path: Path):
+    schema_text = """
+schema_version: 1
+name: group_time_ambiguous
+
+files:
+  fields:
+    role: time_series
+    mode: append
+    path: fields.bp
+    time:
+      variable: time
+      index: step_index
+"""
+    manager = build_campaign_from_schema_text(
+        tmp_path,
+        "group_time_ambiguous.aca",
+        schema_text,
+        ["fields.bp"],
+    )
+
+    with pytest.raises(SchemaInterpretationError, match="files.fields.time requires exactly one"):
+        manager.validate_schema()
+    manager.close()
+
+
+def test_validate_schema_fails_when_group_time_names_file(tmp_path: Path):
+    schema_text = """
+schema_version: 1
+name: group_time_file
+
+files:
+  fields:
+    role: time_series
+    mode: append
+    path: fields.bp
+    time:
+      file: fields
+      variable: time
+"""
+    manager = build_campaign_from_schema_text(
+        tmp_path,
+        "group_time_file.aca",
+        schema_text,
+        ["fields.bp"],
+    )
+
+    with pytest.raises(SchemaInterpretationError, match=r"files.fields.time.file is not supported"):
+        manager.validate_schema()
+    manager.close()
+
+
+def test_validate_schema_fails_when_root_time_references_unknown_group(tmp_path: Path):
+    schema_text = """
+schema_version: 1
+name: root_time_unknown_group
+
+files:
+  fields:
+    role: time_series
+    mode: append
+    path: fields.bp
+
+time:
+  file: missing
+  variable: time
+"""
+    manager = build_campaign_from_schema_text(
+        tmp_path,
+        "root_time_unknown_group.aca",
+        schema_text,
+        ["fields.bp"],
+    )
+
+    with pytest.raises(SchemaInterpretationError, match="time.file references unknown group: missing"):
+        manager.validate_schema()
+    manager.close()
+
+
+def test_validate_schema_fails_when_root_time_references_static_group(tmp_path: Path):
+    schema_text = """
+schema_version: 1
+name: root_time_static_group
+
+files:
+  grid:
+    role: static
+    path: grid.bp
+
+time:
+  file: grid
+  variable: time
+"""
+    manager = build_campaign_from_schema_text(
+        tmp_path,
+        "root_time_static_group.aca",
+        schema_text,
+        ["grid.bp"],
+    )
+
+    with pytest.raises(SchemaInterpretationError, match="time.file references non-time_series group: grid"):
+        manager.validate_schema()
+    manager.close()


### PR DESCRIPTION
## Summary

This PR adds first-pass support for campaign layout schemas.

A schema can now be stored in an ACA through the Manager API or CLI:

```python
manager.set_schema("path/to/schema.yaml")
```

```bash
hpc_campaign manager run.aca schema path/to/schema.yaml
```

The schema is stored as an embedded `TEXT` dataset named `schema.yaml`, regardless of the source filename.

## Schema Validation

This PR also adds metadata-only validation:

```python
layout = manager.validate_schema()
```

Validation checks `schema.yaml` against the datasets registered in the ACA. It verifies that schema `path` and `pattern` entries resolve to live campaign datasets, uses existing `timeseries` metadata for ordered multifile groups, and allows unrelated extra datasets.

Validation does **not** open ADIOS/HDF5 payloads or check variables inside data files yet.

## Supported Layouts

Example schemas were added under `data/schema_examples/` for:

- single append-mode output file
- one-file-per-timestep output files
- static grid + append-mode fields
- static grid + one-file-per-timestep fields
- append-mode grid + append-mode fields
- append-mode grid + one-file-per-timestep fields

The validator also supports applying a root `schema.yaml` to multiple immediate run directories, e.g.:

```text
/schema.yaml
/run1/output.bp
/run2/output.bp
```

In that case, each run directory is validated independently against the same schema.

## Tests

Added tests for:

- API and CLI schema storage
- schema update behavior
- embedded `schema.yaml` contents
- coexistence with existing `timeseries`
- validation against real ACA metadata
- missing required dataset failures
- unmatched pattern failures
- invalid timeseries membership
- multi-run directory validation
